### PR TITLE
AddTo functionality added to the IHeader and Header classes

### DIFF
--- a/SendGrid/SendGridMail/Header.cs
+++ b/SendGrid/SendGridMail/Header.cs
@@ -21,10 +21,9 @@ namespace SendGridMail
             _settings.AddArray(keys, substitutions);
         }
 
-
-        public void AddTo(IEnumerable<string> recipients)
+        public void AddTo(IEnumerable<string> addresses)
         {
-            _settings.AddArray(new List<string> { "to" }, recipients);
+            _settings.AddArray(new List<string> { "to" }, addresses);
         }
 
         public void AddUniqueIdentifier(IDictionary<string, string> identifiers)

--- a/SendGrid/SendGridMail/IHeader.cs
+++ b/SendGrid/SendGridMail/IHeader.cs
@@ -23,8 +23,8 @@ namespace SendGridMail
         /// This adds the "to" array to the X-SMTPAPI header so that multiple recipients
         /// may be addressed in a single email. (but they each get their own email, instead of a single email with multiple TO: addressees)
         /// </summary>
-        /// <param name="recipients">List of email addresses</param>
-        void AddTo(IEnumerable<string> recipients);
+        /// <param name="addresses">List of email addresses</param>
+        void AddTo(IEnumerable<string> addresses);
 
         /// <summary>
         /// This adds parameters and values that will be bassed back through SendGrid's


### PR DESCRIPTION
I found that I needed a way to add the "to:" array to the X-SMTPAPI header, so I made a quick update, as discussed here:
http://community.sendgrid.com/sendgrid/topics/multiple_recipients_with_the_net_api_library
