### PR TITLE
File paths are removed from displaying when attached via the restapi, now only displaying the filename and extension.

### DIFF
--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -85,7 +85,7 @@ namespace SendGridMail.Transport
         private void AttachFiles(ISendGrid message, MultipartEntity multipartEntity)
         {
             var files = FetchFileBodies(message);
-            files.ForEach(kvp => multipartEntity.AddBody(new FileBody("files[" + kvp.Key + "]", kvp.Key, kvp.Value)));
+            files.ForEach(kvp => multipartEntity.AddBody(new FileBody("files[" + Path.GetFileName(kvp.Key) + "]", Path.GetFileName(kvp.Key), kvp.Value)));
         }
 
         private void CheckForErrors(CodeScales.Http.Methods.HttpResponse response)


### PR DESCRIPTION
The entire file path was being displayed to the user when a file was
attached to a message.  This removes the path and only displays the
filename.  Fixes issue #2 https://github.com/sendgrid/sendgrid-csharp/issues/2
