### PR TITLE
Make DeliverAsync awaitable

### DIFF
--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Xml;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace SendGridMail.Transport
 {
@@ -64,7 +65,7 @@ namespace SendGridMail.Transport
         /// Asynchronously delivers a message over SendGrid's Web interface
         /// </summary>
         /// <param name="message"></param>
-        public async void DeliverAsync(ISendGrid message)
+        public async Task DeliverAsync(ISendGrid message)
         {
             var client = new HttpClient
             {
@@ -75,7 +76,7 @@ namespace SendGridMail.Transport
             AttachFormParams(message, content);
             AttachFiles(message, content);
             var response = await client.PostAsync(Endpoint + ".xml", content);
-            CheckForErrorsAsync(response);
+            await CheckForErrorsAsync(response);
         }
 
         #region Support Methods
@@ -162,7 +163,7 @@ namespace SendGridMail.Transport
             }
         }
 
-        private async void CheckForErrorsAsync(HttpResponseMessage response)
+        private async Task CheckForErrorsAsync(HttpResponseMessage response)
         {
             //transport error
             if (response.StatusCode != HttpStatusCode.OK)


### PR DESCRIPTION
One issue with doing async void is that you can't catch the errors that are thrown once you make the first await call inside DeliverAsync. I've added Task as a return value so that this will no longer happen. You can see this by running the example program where no errors are thrown. If you then change it to `transportWeb.DeliverAsync(myMessage).Wait();` you should see an aggregate exception thrown with the only inner exception being a Bad Request.

Excellent job overall.
