### PR TITLE
CC doesn't work on Web API

### DIFF
--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -207,8 +207,7 @@ namespace SendGridMail
 			}
 			if (message.Cc != null)
 			{
-				result = result.Concat(message.Cc.ToList().Select(a => new KeyValuePair<String, String>("cc[]", a.Address)))
-					.ToList();
+				throw new NotSupportedException("CC is not supported by the SendGrid Web API");
 			}
 			return result.Where(r => !String.IsNullOrEmpty(r.Value)).ToList();
 		}


### PR DESCRIPTION
Confirmed by SendGrid on 4/18/2014, "Our API does not currently have the 'cc' parameter"
