### PR TITLE
Sink host introduced

### DIFF
--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -20,7 +20,9 @@ namespace SendGrid
         private static readonly Regex TemplateTest = new Regex(@"<%\s*body\s*%>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex TextUnsubscribeTest = new Regex(@"<%\s*%>", RegexOptions.Compiled);
         private static readonly Regex HtmlUnsubscribeTest = new Regex(@"<%\s*([^\s%]+\s?)+\s*%>", RegexOptions.Compiled);
-		#endregion
+	    private const string SinkHost = "sink.sendgrid.net";
+
+	    #endregion
 
 		#region Initialization and Constructors
         
@@ -96,7 +98,16 @@ namespace SendGrid
 
 		public MailAddress[] To
 		{
-			get { return _message.To.ToArray(); }
+		    get
+		    {
+		        if (_sendToSink)
+		        {
+		            return _message.To
+                        .Select(ma => new MailAddress(string.Format("{0}_at_{1}@{2}", ma.User, ma.Host, SinkHost), ma.DisplayName))
+		                .ToArray();
+		        }
+		        return _message.To.ToArray();
+		    }
 			set
 			{
 				_message.To.Clear();
@@ -125,8 +136,9 @@ namespace SendGrid
 		private List<String> _attachments = new List<String>();
 		private Dictionary<String, MemoryStream> _streamedAttachments = new Dictionary<string, MemoryStream>();
 		private Dictionary<String, String> _contentImages = new Dictionary<string, string>();
+	    private bool _sendToSink;
 
-		public void AddTo(String address)
+	    public void AddTo(String address)
 		{
 			var mailAddress = new MailAddress(address);
 			_message.To.Add(mailAddress);
@@ -216,6 +228,11 @@ namespace SendGrid
 		{
 			headers.Keys.ToList().ForEach(key => Headers[key] = headers[key]);
 		}
+
+	    public void SendToSink(bool value = true)
+	    {
+	        _sendToSink = value;
+	    }
 
 		#endregion
 

--- a/SendGrid/Tests/TestSendgrid.cs
+++ b/SendGrid/Tests/TestSendgrid.cs
@@ -346,5 +346,56 @@ namespace Tests
 			var json = header.JsonString();
 			Assert.AreEqual("{\"filters\" : {\"opentrack\" : {\"settings\" : {\"enable\" : \"0\"}}}}", json);
 		}
+
+        [Test]
+        public void TestSendToSink()
+        {
+            // Arrange
+
+            var message = new SendGridMessage();
+            message.To = new[]
+	        {
+	            new MailAddress("foo@bar.com", "Foo Bar"),
+	        };
+            message.AddTo("foo1@bar1.com");
+
+            // Act
+
+            message.SendToSink();
+
+            // Assert
+
+            Assert.AreEqual("foo_at_bar.com@sink.sendgrid.net", message.To[0].Address);
+            Assert.AreEqual("Foo Bar", message.To[0].DisplayName);
+
+            Assert.AreEqual("foo1_at_bar1.com@sink.sendgrid.net", message.To[1].Address);
+            Assert.AreEqual("", message.To[1].DisplayName);
+        }
+
+        [Test]
+        public void TestSendToSinkOff()
+        {
+            // Arrange
+
+            var message = new SendGridMessage();
+            message.To = new[]
+	        {
+	            new MailAddress("foo@bar.com", "Foo Bar"),
+	        };
+            message.AddTo("foo1@bar1.com");
+            message.SendToSink();
+
+            // Act
+
+            message.SendToSink(false);
+
+            // Assert
+
+            Assert.AreEqual("foo@bar.com", message.To[0].Address);
+            Assert.AreEqual("Foo Bar", message.To[0].DisplayName);
+
+            Assert.AreEqual("foo1@bar1.com", message.To[1].Address);
+            Assert.AreEqual("", message.To[1].DisplayName);
+        }
 	}
 }


### PR DESCRIPTION
I've spent quite some time trying to find "test" send mode for SendGrid. I've implemented "SendToSink" flag which some may find very useful. When it is set to true, the message is sent to *user*\_at\_*host*@sink.sendgrid.net, instead of user@host. 

Reference: https://github.com/sendgrid/docs/issues/83