### PR TITLE
add CC, Bcc support

### DIFF
--- a/SendGrid/SendGridMail/ISendGrid.cs
+++ b/SendGrid/SendGridMail/ISendGrid.cs
@@ -16,6 +16,8 @@ namespace SendGrid
 
 		MailAddress From { get; set; }
 		MailAddress[] To { get; set; }
+        MailAddress[] Cc { get; set; }
+        MailAddress[] Bcc { get; set; }
 		MailAddress[] ReplyTo { get; set; }
 		Dictionary<String, MemoryStream> StreamedAttachments { get; set; }
 		String[] Attachments { get; set; }

--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -107,6 +107,32 @@ namespace SendGrid
 			}
 		}
 
+        public MailAddress[] Cc
+        {
+            get { return _message.CC.ToArray(); }
+            set
+            {
+                _message.CC.Clear();
+                foreach (var mailAddress in value)
+                {
+                    _message.CC.Add(mailAddress);
+                }
+            }
+        }
+
+        public MailAddress[] Bcc
+        {
+            get { return _message.Bcc.ToArray(); }
+            set
+            {
+                _message.Bcc.Clear();
+                foreach (var mailAddress in value)
+                {
+                    _message.Bcc.Add(mailAddress);
+                }
+            }
+        }
+
 		public String Subject
 		{
 			get { return _message.Subject; }
@@ -148,7 +174,29 @@ namespace SendGrid
 			}
 		}
 
-        public Dictionary<String, MemoryStream> StreamedAttachments
+	    public void AddCc(string address)
+	    {
+	        var mailAddress = new MailAddress(address);
+	        _message.CC.Add(mailAddress);
+	    }
+
+	    public void AddCc(MailAddress address)
+	    {
+	        _message.CC.Add(address);
+	    }
+
+	    public void AddBcc(string address)
+	    {
+	        var mailAddress = new MailAddress(address);
+            _message.Bcc.Add(mailAddress);
+	    }
+
+	    public void AddBcc(MailAddress address)
+	    {
+	        _message.Bcc.Add(address);
+	    }
+
+	    public Dictionary<String, MemoryStream> StreamedAttachments
 		{
 			get { return _streamedAttachments; }
 			set { _streamedAttachments = value; }

--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -189,6 +189,17 @@ namespace SendGrid
 					.Concat(message.To.ToList().Select(a => new KeyValuePair<String, String>("toname[]", a.DisplayName)))
 					.ToList();
 			}
+
+		    if (message.Cc != null)
+		    {
+		        result.AddRange(message.Cc.Select(c => new KeyValuePair<string, string>("cc[]", c.Address)));
+		    }
+
+		    if (message.Bcc != null)
+		    {
+		        result.AddRange(message.Bcc.Select(c => new KeyValuePair<string, string>("bcc[]", c.Address)));
+		    }
+            
 			if (message.GetEmbeddedImages().Count > 0) {
 				result = result.Concat(message.GetEmbeddedImages().ToList().Select(x => new KeyValuePair<String, String>(string.Format("content[{0}]", x.Key), x.Value)))
 					.ToList();

--- a/SendGrid/Tests/Transport/TestWebApi.cs
+++ b/SendGrid/Tests/Transport/TestWebApi.cs
@@ -37,6 +37,10 @@ namespace Tests.Transport
 		{
 			// Test Variables
 			const string toAddress = "foobar@outlook.com";
+		    const string ccAddress = "cc@outlook.com";
+		    const string bcc1Address = "bcc1@outlook.com";
+		    const string bcc2Address = "bcc2@outlook.com";
+		    MailAddress[] bccAddresses = {new MailAddress(bcc1Address), new MailAddress(bcc2Address)};
 			const string fromAddress = "test@outlook.com";
 			const string subject = "Test Subject";
 			const string textBody = "Test Text Body";
@@ -47,6 +51,8 @@ namespace Tests.Transport
 
 			var message = new SendGridMessage();
 			message.AddTo(toAddress);
+            message.AddCc(ccAddress);
+		    message.Bcc = bccAddresses;
 			message.From = new MailAddress(fromAddress);
 			message.Subject = subject;
 			message.Text = textBody;
@@ -59,6 +65,9 @@ namespace Tests.Transport
 			Assert.True(result.Any(r => r.Key == "api_user" && r.Value == TestUsername));
 			Assert.True(result.Any(r => r.Key == "api_key" && r.Value == TestPassword));
 			Assert.True(result.Any(r => r.Key == "to[]" && r.Value == toAddress));
+            Assert.True(result.Any(r => r.Key == "cc[]" && r.Value == ccAddress));
+            Assert.True(result.Any(r => r.Key == "bcc[]" && r.Value == bcc1Address));
+            Assert.True(result.Any(r => r.Key == "bcc[]" && r.Value == bcc2Address));
 			Assert.True(result.Any(r => r.Key == "from" && r.Value == fromAddress));
 			Assert.True(result.Any(r => r.Key == "subject" && r.Value == subject));
 			Assert.True(result.Any(r => r.Key == "text" && r.Value == textBody));


### PR DESCRIPTION
CC, Bcc support was missing from the C# APIs, for whatever reason.
Not sure why the formatting looks that way in the diff.  Shows up properly in the editor.
