### PR TITLE
Added AddTo(MailAddress) method

### DIFF
--- a/SendGrid/SendGridMail/ISendGrid.cs
+++ b/SendGrid/SendGridMail/ISendGrid.cs
@@ -47,11 +47,11 @@ namespace SendGrid
 		/// <param name="address">single string eg. 'you@company.com'</param>
 		void AddTo(String address);
 
-        /// <summary>
-        ///     Add to the 'To' address.
-        /// </summary>
-        /// <param name="address">MailAddress object</param>
-        void AddTo(MailAddress address);
+		/// <summary>
+		///     Add to the 'To' address.
+		/// </summary>
+		/// <param name="address">MailAddress object</param>
+		void AddTo(MailAddress address);
 
 		/// <summary>
 		///     Add to the 'To' address.

--- a/SendGrid/SendGridMail/ISendGrid.cs
+++ b/SendGrid/SendGridMail/ISendGrid.cs
@@ -47,6 +47,12 @@ namespace SendGrid
 		/// <param name="address">single string eg. 'you@company.com'</param>
 		void AddTo(String address);
 
+        /// <summary>
+        ///     Add to the 'To' address.
+        /// </summary>
+        /// <param name="address">MailAddress object</param>
+        void AddTo(MailAddress address);
+
 		/// <summary>
 		///     Add to the 'To' address.
 		/// </summary>

--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -170,6 +170,12 @@ namespace SendGrid
 			_message.To.Add(mailAddress);
 		}
 
+		public void AddTo(MailAddress address)
+		{
+			if (address == null) return;
+			_message.To.Add(address);
+		}
+
 		public void AddTo(IEnumerable<String> addresses)
 		{
 			if (addresses == null) return;


### PR DESCRIPTION
There's `AddCc(MailAddress)` and `AddBcc(MailAddress)` methods, but no `AddTo(MailAddress)` method. Since this was a simple addition, why not add this method as well?