### PR TITLE
Additional AddCc and AddBcc to take IEnumerable<String> as with the AddTo function

### DIFF
--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -197,6 +197,14 @@ namespace SendGrid
 	        _message.CC.Add(address);
 	    }
 
+        public void AddCc(IEnumerable<String> addresses)
+        {
+            if (addresses == null) return;
+
+            foreach (var address in addresses.Where(address => address != null))
+                AddCc(address);
+        }
+
 	    public void AddBcc(string address)
 	    {
 	        var mailAddress = new MailAddress(address);
@@ -207,6 +215,14 @@ namespace SendGrid
 	    {
 	        _message.Bcc.Add(address);
 	    }
+
+        public void AddBcc(IEnumerable<String> addresses)
+        {
+            if (addresses == null) return;
+
+            foreach (var address in addresses.Where(address => address != null))
+                AddBcc(address);
+        }
 
 	    public Dictionary<String, MemoryStream> StreamedAttachments
 		{


### PR DESCRIPTION
The `AddTo(IEnumerable<String> addresses` is extremely useful when adding multiple addresses, but the same function overload didn't exist for `AddCc` or `AddBcc`.

This can lead to long-winded client side code such as:

```csharp
if (ccAddresses != null) 
{
    foreach(var ccAddress in ccAddresses)
    {
        message.AddCc(ccAddress);
    }
}
```

Whereas (as with the AddTo) it could be as simple as:

```csharp
message.AddCc(ccAddresses);
```
