### PR TITLE
Change example of setting message recipients not encourging for using AddTo method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ var myMessage = new SendGridMessage();
 // Add the message properties.
 myMessage.From = new MailAddress("john@example.com");
 
-// Add multiple addresses to the To field.
+// Set message recipient using the To field.
+myMessage.To = @"Sam Jackson <sam@example.com>";
+
+// For multiple recipients use AddTo method.
 List<String> recipients = new List<String>
 {
     @"Jeff Smith <jeff@example.com>",
     @"Anna Lidman <anna@example.com>",
     @"Peter Saddow <peter@example.com>"
 };
-
 myMessage.AddTo(recipients);
 
 myMessage.Subject = "Testing the SendGrid Library";


### PR DESCRIPTION
I think, as the basic method of setting recipients, it should be used `To` property. `AddTo` is still good, but should be presented as convinient alternative.