### PR TITLE
Use ConfigureAwait(false) inside DeliverAsync to avoid blocking in ASP.NET

### DIFF
--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -68,8 +68,8 @@ namespace SendGrid
             var content = new MultipartFormDataContent();
             AttachFormParams(message, content);
             AttachFiles(message, content);
-            var response = await _client.PostAsync(Endpoint, content);
-            await ErrorChecker.CheckForErrorsAsync(response);
+            var response = await _client.PostAsync(Endpoint, content).ConfigureAwait(false);
+            await ErrorChecker.CheckForErrorsAsync(response).ConfigureAwait(false);
         }
 
         #region Support Methods


### PR DESCRIPTION
I was running into issues on an ASP.NET application that used SendGrid to deliver emails; although the email was delivered, the await on DeliverAsync never returned. I was able to fix this by using ConfigureAwait(false) in the two await calls inside DeliverAsync, and on the call to DeliverAsync in my code.