### PR TITLE
Templates, Versions and Batches API 

### DIFF
--- a/SendGrid/Example/Program.cs
+++ b/SendGrid/Example/Program.cs
@@ -21,6 +21,9 @@ namespace Example
             Suppressions();
             GlobalSuppressions();
             GlobalStats();
+            Templates();
+            Versions();
+            Batches();
         }
         
         private static void SendAsync(SendGrid.SendGridMessage message)
@@ -259,5 +262,118 @@ namespace Example
             Console.ReadKey();
         }
 
+        private static void Templates()
+        {
+            String apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY", EnvironmentVariableTarget.User);
+            var client = new SendGrid.Client(apiKey);
+
+            // GET TEMPLATES
+            HttpResponseMessage responseGet = client.Templates.Get().Result;
+            Console.WriteLine(responseGet.StatusCode);
+            Console.WriteLine(responseGet.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("These are your current Templates. Press any key to continue.");
+            Console.ReadKey();
+
+            // GET A PARTICULAR TEMPLATE
+            string templateID = "";
+            HttpResponseMessage responseGetUnique = client.Templates.Get(templateID).Result;
+            Console.WriteLine(responseGetUnique.StatusCode);
+            Console.WriteLine(responseGetUnique.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("This is a Template with ID: " + templateID + ".\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // POST TEMPLATE
+            HttpResponseMessage responsePost = client.Templates.Post("C Sharp Templates").Result;
+            var rawString = responsePost.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            var templateId = jsonObject.id.ToString();
+            Console.WriteLine(responsePost.StatusCode);
+            Console.WriteLine(responsePost.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template created.\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // PATCH TEMPLATE
+            HttpResponseMessage responsePatch = client.Templates.Patch(templateId, "CSharpTestTemplatePatched").Result;
+            Console.WriteLine(responsePatch.StatusCode);
+            Console.WriteLine(responsePatch.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template patched.\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // DELETE TEMPLATE
+            Console.WriteLine("Deleting Template, please wait.");
+            HttpResponseMessage responseDelete = client.Templates.Delete(templateId).Result;
+            Console.WriteLine(responseDelete.StatusCode);
+            HttpResponseMessage responseFinal = client.Templates.Get().Result;
+            Console.WriteLine(responseFinal.StatusCode);
+            Console.WriteLine(responseFinal.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template Deleted.\n\nPress any key to end.");
+            Console.ReadKey();
+        }
+
+        private static void Versions()
+        {
+            String apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY", EnvironmentVariableTarget.User);
+            var client = new SendGrid.Client(apiKey);
+
+            // GET A PARTICULAR VERSION
+            string templateID = "";
+            string versionId = "";
+            HttpResponseMessage responseGetUnique = client.Versions.Get(templateID, versionId).Result;
+            Console.WriteLine(responseGetUnique.StatusCode);
+            Console.WriteLine(responseGetUnique.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("This is a Template Version with ID: " + templateID + "/" + versionId + ".\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // POST VERSION
+            HttpResponseMessage responsePost = client.Versions.Post(templateID, "C Sharp Template", "C Sharp <%subject%>", "C Sharp Html <%body%>", "C Sharp Plain <%body%>", true).Result;
+            var rawString = responsePost.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            var templateId = jsonObject.id.ToString();
+            Console.WriteLine(responsePost.StatusCode);
+            Console.WriteLine(responsePost.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template Version created.\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // PATCH VERSION
+            HttpResponseMessage responsePatch = client.Versions.Patch(templateId, versionId, "C Sharp Template Patched", "C Sharp <%subject%> Patched", "C Sharp Html <%body%> Patched", "C Sharp Plain <%body%> Patched", true).Result;
+            Console.WriteLine(responsePatch.StatusCode);
+            Console.WriteLine(responsePatch.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template Version patched.\n\nPress any key to continue.");
+            Console.ReadKey();
+
+            // DELETE VERSION
+            Console.WriteLine("Deleting Template Version, please wait.");
+            HttpResponseMessage responseDelete = client.Versions.Delete(templateId, versionId).Result;
+            Console.WriteLine(responseDelete.StatusCode);
+            HttpResponseMessage responseFinal = client.Templates.Get().Result;
+            Console.WriteLine(responseFinal.StatusCode);
+            Console.WriteLine(responseFinal.Content.ReadAsStringAsync().Result);
+            Console.WriteLine("Template Version Deleted.\n\nPress any key to end.");
+            Console.ReadKey();
+        }
+
+        private static void Batches()
+        {
+            String apiKey = Environment.GetEnvironmentVariable( "SENDGRID_APIKEY", EnvironmentVariableTarget.User );
+            var client = new SendGrid.Client( apiKey );
+
+            // GET A PARTICULAR BATCH
+            string batchID = "";
+            HttpResponseMessage responseGetUnique = client.Batches.Get( batchID ).Result;
+            Console.WriteLine( responseGetUnique.StatusCode );
+            Console.WriteLine( responseGetUnique.Content.ReadAsStringAsync().Result );
+            Console.WriteLine( "This is a Batch with ID: " + batchID + ".\n\nPress any key to continue." );
+            Console.ReadKey();
+
+            // POST BATCH
+            HttpResponseMessage responsePost = client.Batches.Post().Result;
+            var rawString = responsePost.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse( rawString );
+            var batchId = jsonObject.id.ToString();
+            Console.WriteLine( responsePost.StatusCode );
+            Console.WriteLine( responsePost.Content.ReadAsStringAsync().Result );
+            Console.WriteLine( "Batch created.\n\nPress any key to continue." );
+            Console.ReadKey();
+        }
     }
 }

--- a/SendGrid/SendGrid/Client.cs
+++ b/SendGrid/SendGrid/Client.cs
@@ -13,6 +13,8 @@ namespace SendGrid
     public class Client
     {
         private string _apiKey;
+        private string _userName;
+        private string _password;
         public APIKeys ApiKeys;
         public UnsubscribeGroups UnsubscribeGroups;
         public Suppressions Suppressions;
@@ -38,15 +40,34 @@ namespace SendGrid
         {
             _baseUri = new Uri(baseUri);
             _apiKey = apiKey;
+            Initialize();   
+        }
+
+        /// <summary>
+        ///     Create a client that connects to the SendGrid Web API
+        /// </summary>
+        /// <param name="username">Your SendGrid Username</param>
+        /// <param name="password">Your SendGrid Password</param>
+        /// <param name="baseUri">Base SendGrid API Uri</param>
+        public Client(string userName, string password, string baseUri = "https://api.sendgrid.com/")
+        {
+            _baseUri = new Uri( baseUri );
+            _userName = userName;
+            _password = password;
+            Initialize();
+        }
+
+        private void Initialize()
+        {
             Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            ApiKeys = new APIKeys(this);
-            UnsubscribeGroups = new UnsubscribeGroups(this);
-            Suppressions = new Suppressions(this);
-            GlobalSuppressions = new GlobalSuppressions(this);
-            GlobalStats = new GlobalStats(this);
-            Templates = new Templates(this);
-            Versions = new Versions(this);
-            Batches = new Batches(this);
+            ApiKeys = new APIKeys( this );
+            UnsubscribeGroups = new UnsubscribeGroups( this );
+            Suppressions = new Suppressions( this );
+            GlobalSuppressions = new GlobalSuppressions( this );
+            GlobalStats = new GlobalStats( this );
+            Templates = new Templates( this );
+            Versions = new Versions( this );
+            Batches = new Batches( this );
         }
 
         /// <summary>
@@ -65,7 +86,15 @@ namespace SendGrid
                     client.BaseAddress = _baseUri;
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaType));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+                    if (!string.IsNullOrWhiteSpace(_userName) && !string.IsNullOrWhiteSpace(_password))
+                    {
+                        var byteArray = Encoding.ASCII.GetBytes(string.Format("{0}:{1}", _userName, _password));
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+                    }
+                    else
+                    {
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+                    }
                     client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "sendgrid/" + Version + ";csharp");
 
                     switch (method)

--- a/SendGrid/SendGrid/Client.cs
+++ b/SendGrid/SendGrid/Client.cs
@@ -18,6 +18,9 @@ namespace SendGrid
         public Suppressions Suppressions;
         public GlobalSuppressions GlobalSuppressions;
         public GlobalStats GlobalStats;
+        public Templates Templates;
+        public Versions Versions;
+        public Batches Batches;
         public string Version;
         private Uri _baseUri;
         private const string MediaType = "application/json";
@@ -41,6 +44,9 @@ namespace SendGrid
             Suppressions = new Suppressions(this);
             GlobalSuppressions = new GlobalSuppressions(this);
             GlobalStats = new GlobalStats(this);
+            Templates = new Templates(this);
+            Versions = new Versions(this);
+            Batches = new Batches(this);
         }
 
         /// <summary>

--- a/SendGrid/SendGrid/Resources/Batches.cs
+++ b/SendGrid/SendGrid/Resources/Batches.cs
@@ -1,0 +1,43 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SendGrid.Resources
+{
+    public class Batches
+    {
+        private string _endpoint;
+        private Client _client;
+
+        /// <summary>
+        /// Constructs the SendGrid Batches object.
+        /// See https://sendgrid.com/docs/API_Reference/Web_API_v3/cancel_schedule_send.html
+        /// </summary>
+        /// <param name="client">SendGrid Web API v3 client</param>
+        /// <param name="endpoint">Resource endpoint, do not prepend slash</param>
+        public Batches(Client client, string endpoint = "v3/mail/batch")
+        {
+            _endpoint = endpoint;
+            _client = client;
+        }
+
+        /// <summary>
+        /// Validate whether or not a batch id is valid
+        /// </summary>
+        /// <param name="batchId">The batch id you want to check</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/cancel_schedule_send.html</returns>
+        public async Task<HttpResponseMessage> Get(string batchId)
+        {
+            return await _client.Get(_endpoint + "/" + batchId);
+        }
+
+        /// <summary>
+        /// Create a new Batch ID
+        /// </summary>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/cancel_schedule_send.html</returns>
+        public async Task<HttpResponseMessage> Post()
+        {
+            return await _client.Post(_endpoint, null);
+        }
+
+    }
+}

--- a/SendGrid/SendGrid/Resources/Templates.cs
+++ b/SendGrid/SendGrid/Resources/Templates.cs
@@ -1,0 +1,76 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace SendGrid.Resources
+{
+    public class Templates
+    {
+        private string _endpoint;
+        private Client _client;
+
+        /// <summary>
+        /// Constructs the SendGrid Templates object.
+        /// See https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html
+        /// </summary>
+        /// <param name="client">SendGrid Web API v3 client</param>
+        /// <param name="endpoint">Resource endpoint, do not prepend slash</param>
+        public Templates(Client client, string endpoint = "v3/templates")
+        {
+            _endpoint = endpoint;
+            _client = client;
+        }
+
+        /// <summary>
+        /// Retrieve all templates associated with the user.
+        /// </summary>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html</returns>
+        public async Task<HttpResponseMessage> Get()
+        {
+            return await _client.Get(_endpoint);
+        }
+
+        /// <summary>
+        /// Get information on a single template.
+        /// </summary>
+        /// <param name="templateId">ID of the template to fetch</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html</returns>
+        public async Task<HttpResponseMessage> Get(string templateId)
+        {
+            return await _client.Get(_endpoint + "/" + templateId);
+        }
+
+        /// <summary>
+        /// Create a new template.
+        /// </summary>
+        /// <param name="templateName">The name of the new template</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html</returns>
+        public async Task<HttpResponseMessage> Post(string templateName)
+        {
+            var data = new JObject {{"name", templateName}};
+            return await _client.Post(_endpoint, data);
+        }
+
+        /// <summary>
+        /// Patch a template.
+        /// </summary>
+        /// <param name="templateName">The new name of the template</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html</returns>
+        public async Task<HttpResponseMessage> Patch(string templateId, string templateName)
+        {
+            var data = new JObject {{"name", templateName}};
+            return await _client.Patch(_endpoint + "/" + templateId, data);
+        }
+
+        /// <summary>
+        /// Delete a template.
+        /// </summary>
+        /// <param name="unsubscribeGroupId">ID of the template to delete</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html</returns>
+        public async Task<HttpResponseMessage> Delete(string unsubscribeGroupId)
+        {
+            return await _client.Delete(_endpoint + "/" + unsubscribeGroupId);
+        }
+
+    }
+}

--- a/SendGrid/SendGrid/Resources/Versions.cs
+++ b/SendGrid/SendGrid/Resources/Versions.cs
@@ -1,0 +1,88 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace SendGrid.Resources
+{
+    public class Versions
+    {
+        private string _endpoint;
+        private Client _client;
+
+        /// <summary>
+        /// Constructs the SendGrid Versions object.
+        /// See https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html
+        /// </summary>
+        /// <param name="client">SendGrid Web API v3 client</param>
+        /// <param name="endpoint">Resource endpoint, do not prepend slash</param>
+        public Versions(Client client, string endpoint = "v3/templates")
+        {
+            _endpoint = endpoint;
+            _client = client;
+        }
+
+        /// <summary>
+        /// Get information on a single template version.
+        /// </summary>
+        /// <param name="templateId">ID of the template to fetch</param>
+        /// <param name="versionId">ID of the template version to fetch</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html</returns>
+        public async Task<HttpResponseMessage> Get(string templateId, string versionId)
+        {
+            return await _client.Get(_endpoint + "/" + templateId + "/versions/" + versionId);
+        }
+
+        /// <summary>
+        /// Create a new template version.
+        /// </summary>
+        /// <param name="templateId">ID of the template to add the version to</param>
+        /// <param name="versionName">The name of the new version</param>
+        /// <param name="subject">The subject of the new version</param>
+        /// <param name="htmlContent">The HTML content of the new version</param>
+        /// <param name="plainContent">The Text/plain content of the new version</param>
+        /// <param name="active">Set this version as active</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html</returns>
+        public async Task<HttpResponseMessage> Post(string templateId, string versionName, string subject, string htmlContent, string plainContent, bool active = false)
+        {
+            var data = new JObject {{"name", versionName},
+                                    {"subject", subject},
+                                    {"html_content", htmlContent},
+                                    {"plain_content", plainContent},
+                                    {"active", active ? 1 : 0}};
+            return await _client.Post(_endpoint + "/" + templateId + "/versions", data);
+        }
+
+        /// <summary>
+        /// Patch a template version.
+        /// </summary>
+        /// <param name="templateId">ID of the template to add the version to</param>
+        /// <param name="versionId">ID of the template version to update</param>
+        /// <param name="versionName">Updated name of the template</param>
+        /// <param name="subject">Updated subject of the new version</param>
+        /// <param name="htmlContent">The HTML content of the new version</param>
+        /// <param name="plainContent">The Text/plain content of the new version</param>
+        /// <param name="active">Set this version as active</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html</returns>
+        public async Task<HttpResponseMessage> Patch(string templateId, string versionId, string versionName, string subject, string htmlContent, string plainContent, bool active = false)
+        {
+            var data = new JObject {{"name", versionName},
+                                    {"subject", subject},
+                                    {"html_content", htmlContent},
+                                    {"plain_content", plainContent},
+                                    {"active", active}};
+            return await _client.Patch(_endpoint + "/" + templateId + "/versions/" + versionId, data);
+        }
+
+        /// <summary>
+        /// Delete a template version.
+        /// </summary>
+        /// <param name="templateId">ID of the template to delete</param>
+        /// <param name="versionId">ID of the template version to delete</param>
+        /// <returns>https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html</returns>
+        public async Task<HttpResponseMessage> Delete(string templateId, string versionId)
+        {
+            return await _client.Delete(_endpoint + "/" + templateId + "/versions/" + versionId);
+        }
+
+    }
+}

--- a/SendGrid/SendGrid/SendGrid.csproj
+++ b/SendGrid/SendGrid/SendGrid.csproj
@@ -65,9 +65,12 @@
   <ItemGroup>
     <Compile Include="Client.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Resources\Batches.cs" />
     <Compile Include="Resources\GlobalSuppressions.cs" />
     <Compile Include="Resources\GlobalStats.cs" />
     <Compile Include="Resources\Suppressions.cs" />
+    <Compile Include="Resources\Versions.cs" />
+    <Compile Include="Resources\Templates.cs" />
     <Compile Include="Resources\UnsubscribeGroups.cs" />
     <Compile Include="Resources\APIKeys.cs" />
   </ItemGroup>

--- a/SendGrid/UnitTest/UnitTest.cs
+++ b/SendGrid/UnitTest/UnitTest.cs
@@ -417,8 +417,9 @@ namespace UnitTest
     public class Batches
     {
         static string _baseUri = "https://api.sendgrid.com/";
-        static string _apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
-        public Client client = new Client(_apiKey, _baseUri);
+        static string _userName = Environment.GetEnvironmentVariable("SENDGRID_USERNAME");
+        static string _password = Environment.GetEnvironmentVariable("SENDGRID_PASSWORD");
+        public Client client = new Client(_userName, _password, _baseUri);
         private static string _batch_id = "";
 
         [Test]

--- a/SendGrid/UnitTest/UnitTest.cs
+++ b/SendGrid/UnitTest/UnitTest.cs
@@ -279,4 +279,175 @@ namespace UnitTest
             Assert.IsNotNull(jsonObject);
         }
     }
+
+    [TestFixture]
+    public class Templates
+    {
+        static string _baseUri = "https://api.sendgrid.com/";
+        static string _apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
+        public Client client = new Client(_apiKey, _baseUri);
+        private static string _template_id = "";
+
+        [Test]
+        public void TemplatesIntegrationTest()
+        {
+            string templateId = "";
+
+            TestGet();
+            TestGetUnique(templateId);
+            TestPost();
+            TestPatch();
+            TestDelete();
+        }
+
+        private void TestGet()
+        {
+            HttpResponseMessage response = client.Templates.Get().Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JsonConvert.DeserializeObject(rawString);
+            Assert.IsNotNull(jsonObject);
+        }
+
+        private void TestGetUnique(string templateId)
+        {
+            HttpResponseMessage response = client.Templates.Get(templateId).Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JsonConvert.DeserializeObject(rawString);
+            Assert.IsNotNull(jsonObject);
+        }
+
+        private void TestPost()
+        {
+            HttpResponseMessage response = client.Templates.Post("C Sharp Template").Result;
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            string name = jsonObject.name.ToString();
+            _template_id = jsonObject.id.ToString();
+            Assert.IsNotNull(name);
+            Assert.IsNotNull(_template_id);
+        }
+
+        private void TestPatch()
+        {
+            HttpResponseMessage response = client.Templates.Patch(_template_id, "CSharpTemplatePatched").Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            _template_id = jsonObject.id.ToString();
+            string name = jsonObject.name.ToString();
+            Assert.IsNotNull(_template_id);
+            Assert.IsNotNull(name);
+        }
+
+        private void TestDelete()
+        {
+            HttpResponseMessage response = client.Templates.Delete(_template_id).Result;
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        }
+    }
+
+    [TestFixture]
+    public class Versions
+    {
+        static string _baseUri = "https://api.sendgrid.com/";
+        static string _apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
+        public Client client = new Client(_apiKey, _baseUri);
+        private static string _template_id = "";
+        private static string _version_id = "";
+
+        [Test]
+        public void VersionsIntegrationTest()
+        {
+            string templateId = "";
+            string versionId = "";
+
+            TestGetUnique(templateId, versionId);
+            TestPost(templateId);
+            TestPatch();
+            TestDelete();
+        }
+
+        private void TestGetUnique(string templateId, string versionId)
+        {
+            HttpResponseMessage response = client.Versions.Get(templateId, versionId).Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JsonConvert.DeserializeObject(rawString);
+            Assert.IsNotNull(jsonObject);
+        }
+
+        private void TestPost(string templateId)
+        {
+            HttpResponseMessage response = client.Versions.Post(templateId, "C Sharp Template", "C Sharp <%subject%>", "C Sharp Html <%body%>", "C Sharp Plain <%body%>", true).Result;
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            _version_id = jsonObject.id.ToString();
+            _template_id = jsonObject.template_id.ToString();
+            string name = jsonObject.name.ToString();
+            Assert.IsNotNull(name);
+            Assert.IsNotNull(_version_id);
+            Assert.IsNotNull(_template_id);
+        }
+
+        private void TestPatch()
+        {
+            HttpResponseMessage response = client.Versions.Patch(_template_id, _version_id, "C Sharp Template Patched", "C Sharp <%subject%> Patched", "C Sharp Html <%body%> Patched", "C Sharp Plain <%body%> Patched", true).Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            _version_id = jsonObject.id.ToString();
+            string name = jsonObject.name.ToString();
+            Assert.IsNotNull(name);
+            Assert.IsNotNull(_version_id);
+            Assert.IsNotNull(_template_id);
+        }
+
+        private void TestDelete()
+        {
+            HttpResponseMessage response = client.Versions.Delete(_template_id, _version_id).Result;
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        }
+    }
+
+    [TestFixture]
+    public class Batches
+    {
+        static string _baseUri = "https://api.sendgrid.com/";
+        static string _apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
+        public Client client = new Client(_apiKey, _baseUri);
+        private static string _batch_id = "";
+
+        [Test]
+        public void BatchesIntegrationTest()
+        {
+            string batchId = "";
+            
+            TestGetUnique(batchId);
+            TestPost();
+        }
+        
+        private void TestGetUnique(string templateId)
+        {
+            HttpResponseMessage response = client.Batches.Get(templateId).Result;
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JsonConvert.DeserializeObject(rawString);
+            Assert.IsNotNull(jsonObject);
+        }
+
+        private void TestPost()
+        {
+            HttpResponseMessage response = client.Batches.Post().Result;
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            string rawString = response.Content.ReadAsStringAsync().Result;
+            dynamic jsonObject = JObject.Parse(rawString);
+            _batch_id = jsonObject.batch_id.ToString();
+            Assert.IsNotNull(_batch_id);
+        }
+ 
+    }
 }


### PR DESCRIPTION
Hi,

I've implemented the Transactional Template API (Templates and Versions) and also the Batches API to allow cancelling a scheduled send. 

However, on the Batches API, there is a bug whereby it won't allow access to the API using an API key, only with a username and password. I've logged this with SendGrid Support, but to get a working test I implemented the username:password access on the client. I thought this was useful so I've included it in this pull request too 

https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html
https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/versions.html
https://sendgrid.com/docs/API_Reference/Web_API_v3/cancel_schedule_send.html