### PR TITLE
Added constructor that allows a MailMessage to be passed in.

### DIFF
--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -42,6 +42,11 @@ namespace SendGrid
             Headers = new Dictionary<string, string>();
         }
 
+	    public SendGridMessage(MailMessage mailMessage)
+	    {
+	        _message = mailMessage;
+	    }
+
 		public SendGridMessage(MailAddress from, MailAddress[] to,
 			String subject, String html, String text, IHeader header = null) : this()
 		{

--- a/SendGrid/SendGridMail/SendGrid.cs
+++ b/SendGrid/SendGridMail/SendGrid.cs
@@ -44,7 +44,19 @@ namespace SendGrid
 
 	    public SendGridMessage(MailMessage mailMessage)
 	    {
-	        _message = mailMessage;
+            From = mailMessage.From;
+            To = mailMessage.To.ToArray();
+
+            _message.Subject = mailMessage.Subject;
+
+	        if (mailMessage.IsBodyHtml)
+	        {
+	            Html = mailMessage.Body;
+	        }
+	        else
+	        {
+	            Text = mailMessage.Body;
+	        }
 	    }
 
 		public SendGridMessage(MailAddress from, MailAddress[] to,


### PR DESCRIPTION
Hopefully this is fairly straightforward, but for code that makes extensive use of System.Net.Mail.MailMessage being able to just pass one in would be helpful to migration.