### PR TITLE
Added ability for SendGrid.Client to Authenticate using credentials 

### DIFF
--- a/SendGrid/UnitTest/UnitTest.cs
+++ b/SendGrid/UnitTest/UnitTest.cs
@@ -14,12 +14,25 @@ namespace UnitTest
     {
         static string _baseUri = "https://api.sendgrid.com/";
         static string _apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
-        public Client client = new Client(_apiKey, _baseUri);
+        static string _sendGridUsername = Environment.GetEnvironmentVariable("SENDGRID_USERNAME");
+        static string _sendGridPassword = Environment.GetEnvironmentVariable("SENDGRID_PASSWORD");
+        public Client client;
         private static string _api_key_id = "";
 
         [Test]
-        public void ApiKeysIntegrationTest()
+        public void ApiKeysIntegrationTestUsingApiKey()
         {
+            client = new Client(_apiKey, _baseUri);
+            TestGet();
+            TestPost();
+            TestPatch();
+            TestDelete();
+        }
+
+        [Test]
+        public void ApiKeysIntegrationTestUsingCredentials()
+        {
+            client = new Client(new NetworkCredential(_sendGridUsername, _sendGridPassword), _baseUri);
             TestGet();
             TestPost();
             TestPatch();


### PR DESCRIPTION
Created another Client constructor that takes in NetworkCredentials instead of an ApiKey.  The client will try to use the ApiKey first, then credentials, and then no authorization if both are null.

Updated ApiKeys integration tests to use both client authentication types.