### PR TITLE
Making the Web transport IDisposable 

### DIFF
--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -12,7 +12,7 @@ using SendGrid.SmtpApi;
 // ReSharper disable MemberCanBePrivate.Global
 namespace SendGrid
 {
-    public class Web : ITransport
+    public class Web : ITransport, IDisposable
     {
         #region Properties
 
@@ -21,6 +21,8 @@ namespace SendGrid
         private readonly NetworkCredential _credentials;
         private readonly HttpClient _client;
         private readonly string _apiKey;
+        private bool _disposed = false;
+
 
         #endregion
 
@@ -182,5 +184,19 @@ namespace SendGrid
         }
 
         #endregion
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                _client.Dispose();
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
     }
 }

--- a/SendGrid/SendGridMail/Transport/Web.cs
+++ b/SendGrid/SendGridMail/Transport/Web.cs
@@ -23,7 +23,6 @@ namespace SendGrid
         private readonly string _apiKey;
         private bool _disposed = false;
 
-
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Very simple change to make the `Web` transport `IDisposable` to enable consumers to dispose of the underlying resources (i.e. `HttpClient`)