### PR TITLE
Align contributing guidelines to actual example code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ git clone https://github.com/sendgrid/sendgrid-csharp.git
 
 First, get your free SendGrid account [here](https://sendgrid.com/free?source=sendgrid-csharp).
 
-Next, update your Environment (user space) with your [SENDGRID_API_KEY](https://app.sendgrid.com/settings/api_keys).
+Next, update your Environment (user space) with your [SENDGRID_APIKEY](https://app.sendgrid.com/settings/api_keys).
 
 ##### Execute: #####
 


### PR DESCRIPTION
Hello!

Just getting my feet wet and ran into this. The example code checks for the "SENDGRID_APIKEY" environment variable, so I thought the documentation should reflect that. I know this is minor.