### PR TITLE
Call constructor with an email inside unit test.

### DIFF
--- a/SendGrid/UnitTest/UnitTest.cs
+++ b/SendGrid/UnitTest/UnitTest.cs
@@ -79,9 +79,8 @@ namespace UnitTest
         {
             Mail mail = new Mail();
 
-            Email email = new Email();
+            Email email = new Email("test@example.com");
             email.Name = "Example User";
-            email.Address = "test@example.com";
             mail.From = email;
 
             mail.Subject = "Hello World from the SendGrid CSharp Library";


### PR DESCRIPTION
This patch makes sure that the other constructor of Email is called during the unit test. This should be merged before pull-request #345 that will fail on this test. The setter of Name should be changed to something like the code below by @stevensona  inside his pull request:

```C#
set
{
  _name = value?.Trim(Quote);
}
```

p.s. I don't think we need a CLA for such a minor change in your unit tests or do we?