### PR TITLE
.NET 4.0 dependency wrong

### DIFF
--- a/nuspec/Sendgrid.9.0.8.nuspec
+++ b/nuspec/Sendgrid.9.0.8.nuspec
@@ -17,7 +17,6 @@
         <dependencies>
             <group targetFramework=".NETFramework4.0">
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
-                <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" />
             </group>
             <group targetFramework=".NETStandard1.3">
                 <dependency id="NETStandard.Library" version="1.6.1" />


### PR DESCRIPTION
Are you sure we need the Microsoft.AspNetCore.Http.Abstractions in .NET 4.0? I tested it without this dependency and it worked without trouble. Please remove this unnecessary dependency. Thank you.