### PR TITLE
AddTo, AddBcc, AddCc and SetFrom that just takes an email and name #408

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -7,6 +7,7 @@ namespace SendGrid.Helpers.Mail
 {
     using Model;
     using Newtonsoft.Json;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -134,6 +135,19 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Add a recipient email.
         /// </summary>
+        /// <param name="email">Specify the recipient's email</param>
+        /// <param name="name">Specify the recipient's name</param>
+        public void AddTo(string email, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                throw new ArgumentNullException("email");
+
+            AddTo(new EmailAddress(email, name));
+        }
+
+        /// <summary>
+        /// Add a recipient email.
+        /// </summary>
         /// <param name="email">An email recipient that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the recipient email.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
@@ -239,6 +253,19 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Add a cc email recipient.
         /// </summary>
+        /// <param name="email">Specify the recipient's email</param>
+        /// <param name="name">Specify the recipient's name</param>
+        public void AddCc(string email, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                throw new ArgumentNullException("email");
+
+            AddCc(new EmailAddress(email, name));
+        }
+
+        /// <summary>
+        /// Add a cc email recipient.
+        /// </summary>
         /// <param name="email">An email recipient that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the cc email.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
@@ -339,6 +366,19 @@ namespace SendGrid.Helpers.Mail
                 }
             };
             return;
+        }
+
+        /// <summary>
+        /// Add a bcc recipient emails.
+        /// </summary>
+        /// <param name="email">Specify the recipient's email</param>
+        /// <param name="name">Specify the recipient's name</param>
+        public void AddBcc(string email, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                throw new ArgumentNullException("email");
+
+            AddBcc(new EmailAddress(email, name));
         }
 
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -894,6 +894,21 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Set the from email.
         /// </summary>
+        /// <param name="email">Specify the recipient's email</param>
+        /// <param name="name">Specify the recipient's name</param>
+        public void SetFrom(string email, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                throw new ArgumentNullException("email");
+            }
+
+            SetFrom(new EmailAddress(email, name));
+        }
+
+        /// <summary>
+        /// Set the from email.
+        /// </summary>
         /// <param name="email">An email object containing the email address and name of the sender. Unicode encoding is not supported for the from field.</param>
         public void SetFrom(EmailAddress email)
         {

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -79,6 +79,14 @@
             msg.SetSubject("Hello World from the SendGrid CSharp Library");
             msg.AddContent(MimeType.Html, "HTML content");
             Console.WriteLine(msg.Serialize());
+
+            msg = new SendGridMessage();
+            msg.SetFrom("test@example.com");
+            msg.AddTo("test@example.com");
+            msg.SetSubject("Hello World from the SendGrid CSharp Library");
+            msg.AddContent(MimeType.Text, "Textual content");
+            msg.AddContent(MimeType.Html, "HTML content");
+            Assert.True(msg.Serialize() == "{\"from\":{\"email\":\"test@example.com\"},\"personalizations\":[{\"to\":[{\"email\":\"test@example.com\"}],\"subject\":\"Hello World from the SendGrid CSharp Library\"}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Textual content\"},{\"type\":\"text/html\",\"value\":\"HTML content\"}]}");
         }
 
         [Fact]
@@ -1863,6 +1871,33 @@
             };
             msg.SetFrom(fromEmail);
             Assert.True(msg.Serialize() == "{\"from\":{\"name\":\"Test User1\",\"email\":\"test1@example.com\"}}");
+        }
+
+        [Fact]
+        public void TestSetFromArgumentNullExceptionIfNullEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(()=> msg.SetFrom(null, "Example User"));
+        }
+
+        [Fact]
+        public void TestSetFromArgumentEmptyExceptionIfEmptyEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(()=> msg.SetFrom(string.Empty, "Example User"));
+        }
+
+        
+        [Fact]
+        public void TestSetFromWithOutEmailAddressObject()
+        {
+            var msg = new SendGridMessage();
+            msg.SetFrom("test1@example.com","Test User1");
+            Assert.True(msg.Serialize() == "{\"from\":{\"name\":\"Test User1\",\"email\":\"test1@example.com\"}}");
+
+            msg = new SendGridMessage();
+            msg.SetFrom("test1@example.com");
+            Assert.True(msg.Serialize() == "{\"from\":{\"email\":\"test1@example.com\"}}");
         }
 
         [Fact]

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -81,6 +81,25 @@
             Console.WriteLine(msg.Serialize());
         }
 
+        [Fact]
+        public void TestSendSingleEmailWithHelperWithOutEmailObject()
+        {
+            var msg = new SendGridMessage();
+            msg.SetFrom(new EmailAddress("test@example.com"));
+            msg.AddTo("test@example.com");
+            msg.SetSubject("Hello World from the SendGrid CSharp Library");
+            msg.AddContent(MimeType.Text, "Textual content");
+            msg.AddContent(MimeType.Html, "HTML content");
+            Assert.True(msg.Serialize() == "{\"from\":{\"email\":\"test@example.com\"},\"personalizations\":[{\"to\":[{\"email\":\"test@example.com\"}],\"subject\":\"Hello World from the SendGrid CSharp Library\"}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Textual content\"},{\"type\":\"text/html\",\"value\":\"HTML content\"}]}");
+
+            msg = new SendGridMessage();
+            msg.SetFrom(new EmailAddress("test@example.com"));
+            msg.AddTo("test@example.com");
+            msg.SetSubject("Hello World from the SendGrid CSharp Library");
+            msg.AddContent(MimeType.Html, "HTML content");
+            Console.WriteLine(msg.Serialize());
+        }
+
         // All paramaters available for sending an email
         [Fact]
         public void TestKitchenSink()
@@ -89,6 +108,7 @@
             msg.SetFrom(new EmailAddress("test1@example.com", "Example User1"));
             msg.SetGlobalSubject("Hello World from the SendGrid CSharp Library");
             msg.AddTo(new EmailAddress("test2@example.com", "Example User2"));
+            msg.AddTo("test-2@example.com", "Example User-2");
             msg.AddTo(new EmailAddress("test3@example.com", "Example User3"));
             var emails = new List<EmailAddress>
             {
@@ -104,14 +124,17 @@
                 new EmailAddress("test9@example.com", "Example User9")
             };
             msg.AddCcs(emails);
+            msg.AddCc("test-9@example.com", "Example User-9");
             msg.AddBcc(new EmailAddress("test10example.com", "Example User10"));
             msg.AddBcc(new EmailAddress("test11@example.com", "Example User11"));
+             
             emails = new List<EmailAddress>
             {
                 new EmailAddress("test12@example.com", "Example User12"),
                 new EmailAddress("test13@example.com", "Example User13")
             };
             msg.AddBccs(emails);
+            msg.AddBcc("test-13@example.com", "Example User-13");
             msg.SetSubject("Thank you for signing up, % name %");
             msg.AddHeader("X-Test1", "True1");
             msg.AddHeader("X-Test2", "Test2");
@@ -208,6 +231,7 @@
             msg.AddCcs(emails, 2);
             msg.AddBcc(new EmailAddress("test34example.com", "Example User34"), 2);
             msg.AddBcc(new EmailAddress("test35@example.com", "Example User35"), 2);
+         
             emails = new List<EmailAddress>
             {
                 new EmailAddress("test36@example.com", "Example User36"),
@@ -323,7 +347,7 @@
                                    "some source",
                                    "some term");
             msg.SetReplyTo(new EmailAddress("test+reply@example.com", "Reply To Me"));
-            Assert.True(msg.Serialize() == "{\"from\":{\"name\":\"Example User1\",\"email\":\"test1@example.com\"},\"subject\":\"Hello World from the SendGrid CSharp Library\",\"personalizations\":[{\"to\":[{\"name\":\"Example User2\",\"email\":\"test2@example.com\"},{\"name\":\"Example User3\",\"email\":\"test3@example.com\"},{\"name\":\"Example User4\",\"email\":\"test4@example.com\"},{\"name\":\"Example User5\",\"email\":\"test5@example.com\"}],\"cc\":[{\"name\":\"Example User6\",\"email\":\"test6@example.com\"},{\"name\":\"Example User7\",\"email\":\"test7@example.com\"},{\"name\":\"Example User8\",\"email\":\"test8@example.com\"},{\"name\":\"Example User9\",\"email\":\"test9@example.com\"}],\"bcc\":[{\"name\":\"Example User10\",\"email\":\"test10example.com\"},{\"name\":\"Example User11\",\"email\":\"test11@example.com\"},{\"name\":\"Example User12\",\"email\":\"test12@example.com\"},{\"name\":\"Example User13\",\"email\":\"test13@example.com\"}],\"subject\":\"Thank you for signing up, % name %\",\"headers\":{\"X-Test1\":\"True1\",\"X-Test2\":\"Test2\",\"X-Test3\":\"True3\",\"X-Test4\":\"True4\"},\"substitutions\":{\"%name1%\":\"Example User1\",\"%city2%\":\"Denver1\",\"%name3%\":\"Example User2\",\"%city4%\":\"Orange1\"},\"custom_args\":{\"marketing1\":\"false\",\"transactional1\":\"true\",\"marketing2\":\"true\",\"transactional2\":\"false\"},\"send_at\":1461775051},{\"to\":[{\"name\":\"Example User14\",\"email\":\"test14@example.com\"},{\"name\":\"Example User15\",\"email\":\"test15@example.com\"},{\"name\":\"Example User16\",\"email\":\"test16@example.com\"},{\"name\":\"Example User17\",\"email\":\"test17@example.com\"}],\"cc\":[{\"name\":\"Example User18\",\"email\":\"test18@example.com\"},{\"name\":\"Example User19\",\"email\":\"test19@example.com\"},{\"name\":\"Example User20\",\"email\":\"test20@example.com\"},{\"name\":\"Example User21\",\"email\":\"test21@example.com\"}],\"bcc\":[{\"name\":\"Example User22\",\"email\":\"test22example.com\"},{\"name\":\"Example User23\",\"email\":\"test23@example.com\"},{\"name\":\"Example User24\",\"email\":\"test24@example.com\"},{\"name\":\"Example User25\",\"email\":\"test25@example.com\"}],\"subject\":\"Thank you for signing up, % name % 2\",\"headers\":{\"X-Test5\":\"True5\",\"X-Test6\":\"Test6\",\"X-Test7\":\"True7\",\"X-Test8\":\"True8\"},\"substitutions\":{\"%name5%\":\"Example User5\",\"%city6%\":\"Denver6\",\"%name7%\":\"Example User7\",\"%city8%\":\"Orange8\"},\"custom_args\":{\"marketing3\":\"false\",\"transactional3\":\"true\",\"marketing4\":\"true\",\"transactional4\":\"false\"},\"send_at\":1461775052},{\"to\":[{\"name\":\"Example User26\",\"email\":\"test26@example.com\"},{\"name\":\"Example User27\",\"email\":\"test27@example.com\"},{\"name\":\"Example User28\",\"email\":\"test28@example.com\"},{\"name\":\"Example User29\",\"email\":\"test29@example.com\"}],\"cc\":[{\"name\":\"Example User30\",\"email\":\"test30@example.com\"},{\"name\":\"Example User31\",\"email\":\"test31@example.com\"},{\"name\":\"Example User32\",\"email\":\"test32@example.com\"},{\"name\":\"Example User33\",\"email\":\"test33@example.com\"}],\"bcc\":[{\"name\":\"Example User34\",\"email\":\"test34example.com\"},{\"name\":\"Example User35\",\"email\":\"test35@example.com\"},{\"name\":\"Example User36\",\"email\":\"test36@example.com\"},{\"name\":\"Example User37\",\"email\":\"test37@example.com\"}],\"subject\":\"Thank you for signing up, % name % 3\",\"headers\":{\"X-Test7\":\"True7\",\"X-Test8\":\"Test8\",\"X-Test9\":\"True9\",\"X-Test10\":\"True10\"},\"substitutions\":{\"%name9%\":\"Example User9\",\"%city10%\":\"Denver10\",\"%name11%\":\"Example User11\",\"%city12%\":\"Orange12\"},\"custom_args\":{\"marketing5\":\"false\",\"transactional5\":\"true\",\"marketing6\":\"true\",\"transactional6\":\"false\"},\"send_at\":1461775053}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Textual content\"},{\"type\":\"text/html\",\"value\":\"HTML content\"},{\"type\":\"text/calendar\",\"value\":\"Party Time!!\"},{\"type\":\"text/calendar2\",\"value\":\"Party Time2!!\"}],\"attachments\":[{\"content\":\"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12\",\"type\":\"application/pdf\",\"filename\":\"balance_001.pdf\",\"disposition\":\"attachment\",\"content_id\":\"Balance Sheet\"},{\"content\":\"BwdW\",\"type\":\"image/png\",\"filename\":\"banner.png\",\"disposition\":\"inline\",\"content_id\":\"Banner\"},{\"content\":\"BwdW2\",\"type\":\"image/png\",\"filename\":\"banner2.png\",\"disposition\":\"inline\",\"content_id\":\"Banner 2\"}],\"template_id\":\"13b8f94f-bcae-4ec6-b752-70d6cb59f932\",\"headers\":{\"X-Day\":\"Monday\",\"X-Month\":\"January\",\"X-Year\":\"2017\"},\"sections\":{\"%section1\":\"Substitution for Section 1 Tag\",\"%section2%\":\"Substitution for Section 2 Tag\",\"%section3%\":\"Substitution for Section 3 Tag\"},\"categories\":[\"customer\",\"vip\",\"new_account\"],\"custom_args\":{\"campaign\":\"welcome\",\"sequence2\":\"2\",\"sequence3\":\"3\"},\"send_at\":1461775051,\"asm\":{\"group_id\":3,\"groups_to_display\":[1,4,5]},\"batch_id\":\"some_batch_id\",\"ip_pool_name\":\"23\",\"mail_settings\":{\"bcc\":{\"enable\":true,\"email\":\"test@example.com\"},\"bypass_list_management\":{\"enable\":true},\"footer\":{\"enable\":true,\"text\":\"Some Footer Text\",\"html\":\"Some Footer HTML\"},\"sandbox_mode\":{\"enable\":true},\"spam_check\":{\"enable\":true,\"threshold\":1,\"post_to_url\":\"https://gotchya.example.com\"}},\"tracking_settings\":{\"click_tracking\":{\"enable\":true,\"enable_text\":false},\"open_tracking\":{\"enable\":true,\"substitution_tag\":\"Optional tag to replace with the open image in the body of the message\"},\"subscription_tracking\":{\"enable\":true,\"text\":\"text to insert into the text/plain portion of the message\",\"html\":\"HTML to insert into the text / html portion of the message\",\"substitution_tag\":\"substitution tag\"},\"ganalytics\":{\"enable\":true,\"utm_source\":\"some source\",\"utm_medium\":\"some medium\",\"utm_term\":\"some term\",\"utm_content\":\"some content\",\"utm_campaign\":\"some campaign\"}},\"reply_to\":{\"name\":\"Reply To Me\",\"email\":\"test+reply@example.com\"}}");
+            Assert.True(msg.Serialize() == "{\"from\":{\"name\":\"Example User1\",\"email\":\"test1@example.com\"},\"subject\":\"Hello World from the SendGrid CSharp Library\",\"personalizations\":[{\"to\":[{\"name\":\"Example User2\",\"email\":\"test2@example.com\"},{\"name\":\"Example User-2\",\"email\":\"test-2@example.com\"},{\"name\":\"Example User3\",\"email\":\"test3@example.com\"},{\"name\":\"Example User4\",\"email\":\"test4@example.com\"},{\"name\":\"Example User5\",\"email\":\"test5@example.com\"}],\"cc\":[{\"name\":\"Example User6\",\"email\":\"test6@example.com\"},{\"name\":\"Example User7\",\"email\":\"test7@example.com\"},{\"name\":\"Example User8\",\"email\":\"test8@example.com\"},{\"name\":\"Example User9\",\"email\":\"test9@example.com\"},{\"name\":\"Example User-9\",\"email\":\"test-9@example.com\"}],\"bcc\":[{\"name\":\"Example User10\",\"email\":\"test10example.com\"},{\"name\":\"Example User11\",\"email\":\"test11@example.com\"},{\"name\":\"Example User12\",\"email\":\"test12@example.com\"},{\"name\":\"Example User13\",\"email\":\"test13@example.com\"},{\"name\":\"Example User-13\",\"email\":\"test-13@example.com\"}],\"subject\":\"Thank you for signing up, % name %\",\"headers\":{\"X-Test1\":\"True1\",\"X-Test2\":\"Test2\",\"X-Test3\":\"True3\",\"X-Test4\":\"True4\"},\"substitutions\":{\"%name1%\":\"Example User1\",\"%city2%\":\"Denver1\",\"%name3%\":\"Example User2\",\"%city4%\":\"Orange1\"},\"custom_args\":{\"marketing1\":\"false\",\"transactional1\":\"true\",\"marketing2\":\"true\",\"transactional2\":\"false\"},\"send_at\":1461775051},{\"to\":[{\"name\":\"Example User14\",\"email\":\"test14@example.com\"},{\"name\":\"Example User15\",\"email\":\"test15@example.com\"},{\"name\":\"Example User16\",\"email\":\"test16@example.com\"},{\"name\":\"Example User17\",\"email\":\"test17@example.com\"}],\"cc\":[{\"name\":\"Example User18\",\"email\":\"test18@example.com\"},{\"name\":\"Example User19\",\"email\":\"test19@example.com\"},{\"name\":\"Example User20\",\"email\":\"test20@example.com\"},{\"name\":\"Example User21\",\"email\":\"test21@example.com\"}],\"bcc\":[{\"name\":\"Example User22\",\"email\":\"test22example.com\"},{\"name\":\"Example User23\",\"email\":\"test23@example.com\"},{\"name\":\"Example User24\",\"email\":\"test24@example.com\"},{\"name\":\"Example User25\",\"email\":\"test25@example.com\"}],\"subject\":\"Thank you for signing up, % name % 2\",\"headers\":{\"X-Test5\":\"True5\",\"X-Test6\":\"Test6\",\"X-Test7\":\"True7\",\"X-Test8\":\"True8\"},\"substitutions\":{\"%name5%\":\"Example User5\",\"%city6%\":\"Denver6\",\"%name7%\":\"Example User7\",\"%city8%\":\"Orange8\"},\"custom_args\":{\"marketing3\":\"false\",\"transactional3\":\"true\",\"marketing4\":\"true\",\"transactional4\":\"false\"},\"send_at\":1461775052},{\"to\":[{\"name\":\"Example User26\",\"email\":\"test26@example.com\"},{\"name\":\"Example User27\",\"email\":\"test27@example.com\"},{\"name\":\"Example User28\",\"email\":\"test28@example.com\"},{\"name\":\"Example User29\",\"email\":\"test29@example.com\"}],\"cc\":[{\"name\":\"Example User30\",\"email\":\"test30@example.com\"},{\"name\":\"Example User31\",\"email\":\"test31@example.com\"},{\"name\":\"Example User32\",\"email\":\"test32@example.com\"},{\"name\":\"Example User33\",\"email\":\"test33@example.com\"}],\"bcc\":[{\"name\":\"Example User34\",\"email\":\"test34example.com\"},{\"name\":\"Example User35\",\"email\":\"test35@example.com\"},{\"name\":\"Example User36\",\"email\":\"test36@example.com\"},{\"name\":\"Example User37\",\"email\":\"test37@example.com\"}],\"subject\":\"Thank you for signing up, % name % 3\",\"headers\":{\"X-Test7\":\"True7\",\"X-Test8\":\"Test8\",\"X-Test9\":\"True9\",\"X-Test10\":\"True10\"},\"substitutions\":{\"%name9%\":\"Example User9\",\"%city10%\":\"Denver10\",\"%name11%\":\"Example User11\",\"%city12%\":\"Orange12\"},\"custom_args\":{\"marketing5\":\"false\",\"transactional5\":\"true\",\"marketing6\":\"true\",\"transactional6\":\"false\"},\"send_at\":1461775053}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Textual content\"},{\"type\":\"text/html\",\"value\":\"HTML content\"},{\"type\":\"text/calendar\",\"value\":\"Party Time!!\"},{\"type\":\"text/calendar2\",\"value\":\"Party Time2!!\"}],\"attachments\":[{\"content\":\"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12\",\"type\":\"application/pdf\",\"filename\":\"balance_001.pdf\",\"disposition\":\"attachment\",\"content_id\":\"Balance Sheet\"},{\"content\":\"BwdW\",\"type\":\"image/png\",\"filename\":\"banner.png\",\"disposition\":\"inline\",\"content_id\":\"Banner\"},{\"content\":\"BwdW2\",\"type\":\"image/png\",\"filename\":\"banner2.png\",\"disposition\":\"inline\",\"content_id\":\"Banner 2\"}],\"template_id\":\"13b8f94f-bcae-4ec6-b752-70d6cb59f932\",\"headers\":{\"X-Day\":\"Monday\",\"X-Month\":\"January\",\"X-Year\":\"2017\"},\"sections\":{\"%section1\":\"Substitution for Section 1 Tag\",\"%section2%\":\"Substitution for Section 2 Tag\",\"%section3%\":\"Substitution for Section 3 Tag\"},\"categories\":[\"customer\",\"vip\",\"new_account\"],\"custom_args\":{\"campaign\":\"welcome\",\"sequence2\":\"2\",\"sequence3\":\"3\"},\"send_at\":1461775051,\"asm\":{\"group_id\":3,\"groups_to_display\":[1,4,5]},\"batch_id\":\"some_batch_id\",\"ip_pool_name\":\"23\",\"mail_settings\":{\"bcc\":{\"enable\":true,\"email\":\"test@example.com\"},\"bypass_list_management\":{\"enable\":true},\"footer\":{\"enable\":true,\"text\":\"Some Footer Text\",\"html\":\"Some Footer HTML\"},\"sandbox_mode\":{\"enable\":true},\"spam_check\":{\"enable\":true,\"threshold\":1,\"post_to_url\":\"https://gotchya.example.com\"}},\"tracking_settings\":{\"click_tracking\":{\"enable\":true,\"enable_text\":false},\"open_tracking\":{\"enable\":true,\"substitution_tag\":\"Optional tag to replace with the open image in the body of the message\"},\"subscription_tracking\":{\"enable\":true,\"text\":\"text to insert into the text/plain portion of the message\",\"html\":\"HTML to insert into the text / html portion of the message\",\"substitution_tag\":\"substitution tag\"},\"ganalytics\":{\"enable\":true,\"utm_source\":\"some source\",\"utm_medium\":\"some medium\",\"utm_term\":\"some term\",\"utm_content\":\"some content\",\"utm_campaign\":\"some campaign\"}},\"reply_to\":{\"name\":\"Reply To Me\",\"email\":\"test+reply@example.com\"}}");
         }
 
         [Fact]
@@ -571,6 +595,33 @@
         }
 
         [Fact]
+        public void TestAddToWithOutEmailAddressObject()
+        {
+            var msg = new SendGridMessage();
+            msg.AddTo("test001@example.com", "Example User");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"to\":[{\"name\":\"Example User\",\"email\":\"test001@example.com\"}]}]}");
+
+            msg = new SendGridMessage();
+            msg.AddTo("test001@example.com");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"to\":[{\"email\":\"test001@example.com\"}]}]}");
+         
+        }
+
+        [Fact]
+        public void TestAddToArgumentNullExceptionIfNullEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(()=> msg.AddTo(null, "Example User"));
+        }
+
+        [Fact]
+        public void TestAddToArgumentNullExceptionIfNoEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(() => msg.AddTo(string.Empty, "Example User"));
+        }
+
+        [Fact]
         public void TestAddTos()
         {
             // Personalization not passed in, Personalization does not exist
@@ -680,6 +731,32 @@
             };
             msg.AddTos(emails);
             Assert.True(msg.Serialize() == "{\"personalizations\":[{\"to\":[{\"name\":\"Example User\",\"email\":\"test028@example.com\"},{\"name\":\"Example User\",\"email\":\"test029@example.com\"},{\"name\":\"Example User\",\"email\":\"test032@example.com\"},{\"name\":\"Example User\",\"email\":\"test033@example.com\"}]},{\"to\":[{\"name\":\"Example User\",\"email\":\"test030@example.com\"},{\"name\":\"Example User\",\"email\":\"test031@example.com\"}]}]}");
+        }
+
+        [Fact]
+        public void TestAddCcWithoutEmailAddressObject()
+        {
+            var msg = new SendGridMessage();
+            msg.AddCc("test001@example.com", "Example User");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"cc\":[{\"name\":\"Example User\",\"email\":\"test001@example.com\"}]}]}");
+
+            msg = new SendGridMessage();
+            msg.AddCc("test001@example.com");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"cc\":[{\"email\":\"test001@example.com\"}]}]}");
+        }
+
+        [Fact]
+        public void TestAddCcArgumentNullExceptionIfNullEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(() => msg.AddCc(null, "Example User"));
+        }
+
+        [Fact]
+        public void TestAddCcArgumentNullExceptionIfEmptyEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(() => msg.AddCc(string.Empty, "Example User"));
         }
 
         [Fact]
@@ -956,6 +1033,32 @@
             msg.Personalizations.Add(personalization);
             msg.AddBcc(new EmailAddress("test011@example.com", "Example User"));
             Assert.True(msg.Serialize() == "{\"personalizations\":[{\"bcc\":[{\"name\":\"Example User\",\"email\":\"test009@example.com\"},{\"name\":\"Example User\",\"email\":\"test011@example.com\"}]},{\"bcc\":[{\"name\":\"Example User\",\"email\":\"test010@example.com\"}]}]}");
+        }
+
+        [Fact]
+        public void TestAddBccWithOutEmailAddressObject()
+        {
+            var msg = new SendGridMessage();
+            msg.AddBcc("test001@example.com", "Example User");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"bcc\":[{\"name\":\"Example User\",\"email\":\"test001@example.com\"}]}]}");
+
+            msg = new SendGridMessage();
+            msg.AddBcc("test001@example.com");
+            Assert.True(msg.Serialize() == "{\"personalizations\":[{\"bcc\":[{\"email\":\"test001@example.com\"}]}]}");
+        }
+        
+        [Fact]
+        public void TestAddBccArgumentNullExceptionIfNullEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(() => msg.AddBcc(null, "Example User"));
+        }
+
+        [Fact]
+        public void TestAddBccArgumentNullExceptionIfEmptyEmailAddressIsSupplied()
+        {
+            var msg = new SendGridMessage();
+            Assert.Throws<ArgumentNullException>(() => msg.AddBcc(string.Empty, "Example User"));
         }
 
         [Fact]


### PR DESCRIPTION
Pull request for [#408](https://github.com/sendgrid/sendgrid-csharp/issues/408). Added support for the SetFrom,  AddTo, AddBc, and AddCc overload method. 

I am throwing exception if email address is blank or empty. Let me know if checks is not required in library.