### PR TITLE
Update SendGridMessage.cs

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -274,6 +274,7 @@ namespace SendGrid.Helpers.Mail
         {
             if (personalization != null)
             {
+                personalization.Ccs = personalization.Ccs ?? new List<EmailAddress>();
                 personalization.Ccs.Add(email);
                 if (this.Personalizations == null)
                 {
@@ -392,6 +393,7 @@ namespace SendGrid.Helpers.Mail
         {
             if (personalization != null)
             {
+                personalization.Bccs = personalization.Bccs ?? new List<EmailAddress>();
                 personalization.Bccs.Add(email);
                 if (this.Personalizations == null)
                 {

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -155,6 +155,7 @@ namespace SendGrid.Helpers.Mail
         {
             if (personalization != null)
             {
+                personalization.Tos = personalization.Tos ?? new List<EmailAddress>();
                 personalization.Tos.Add(email);
                 if (this.Personalizations == null)
                 {


### PR DESCRIPTION
Personalization Tos field can be null

Snippet of the code that was throwing a null pointer exception
```
var msg = new SendGridMessage();
var i = 0;
        to.ForEach(o =>
        {
             if (o.Substitutions!= null && o.Substitutions.Any())
                {
                    p = new Personalization
                    {
                        Tos = new List<EmailAddress>(), //added to fix null pointer exception in sendgrid lib
                        Substitutions = new Dictionary<string, string>(o.Substitutions)
                    };
                }
                var newTemplateId = o.Metadata.ContainsKey("templateId")
                    ? o.Metadata["templateId"]?.ToString()
                    : null;
                msg.TemplateId = newTemplateId ?? msg.TemplateId;
                msg.AddTo(new EmailAddress(o.To),i,p);
```