### PR TITLE
Disable Json.Net reference handling for SendGrid objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,3 +321,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Code
+/.vscode

--- a/src/SendGrid/Helpers/Mail/Model/ASM.cs
+++ b/src/SendGrid/Helpers/Mail/Model/ASM.cs
@@ -24,7 +24,7 @@ namespace SendGrid.Helpers.Mail
         /// Gets or sets an array containing the unsubscribe groups that you would like to be displayed on the unsubscribe preferences page.
         /// https://sendgrid.com/docs/User_Guide/Suppressions/recipient_subscription_preferences.html
         /// </summary>
-        [JsonProperty(PropertyName = "groups_to_display")]
+        [JsonProperty(PropertyName = "groups_to_display", IsReference = false)]
         public List<int> GroupsToDisplay { get; set; }
     }
 }

--- a/src/SendGrid/Helpers/Mail/Model/ASM.cs
+++ b/src/SendGrid/Helpers/Mail/Model/ASM.cs
@@ -11,6 +11,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// An object allowing you to specify how to handle unsubscribes.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class ASM
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/Attachment.cs
+++ b/src/SendGrid/Helpers/Mail/Model/Attachment.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Gets or sets an array of objects in which you can specify any attachments you want to include.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class Attachment
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/BCCSettings.cs
+++ b/src/SendGrid/Helpers/Mail/Model/BCCSettings.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Gets or sets the address specified in the mail_settings.bcc object will receive a blind carbon copy (BCC) of the very first personalization defined in the personalizations array.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class BCCSettings
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/BypassListManagement.cs
+++ b/src/SendGrid/Helpers/Mail/Model/BypassListManagement.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Allows you to bypass all unsubscribe groups and suppressions to ensure that the email is delivered to every single recipient. This should only be used in emergencies when it is absolutely necessary that every recipient receives your email. Ex: outage emails, or forgot password emails.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class BypassListManagement
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/ClickTracking.cs
+++ b/src/SendGrid/Helpers/Mail/Model/ClickTracking.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Allows you to track whether a recipient clicked a link in your email.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class ClickTracking
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/Content.cs
+++ b/src/SendGrid/Helpers/Mail/Model/Content.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Specifies the content of your email. You can include multiple mime types of content, but you must specify at least one. To include more than one mime type, simply add another object to the array containing the type and value parameters. If included, text/plain and text/html must be the first indices of the array in this order. If you choose to include the text/plain or text/html mime types, they must be the first indices of the content array in the order text/plain, text/html.*Content is NOT mandatory if you using a transactional template and have defined the template_id in the Request
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class Content
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/EmailAddress.cs
+++ b/src/SendGrid/Helpers/Mail/Model/EmailAddress.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// An email object containing the email address and name of the sender or recipient.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class EmailAddress
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/FooterSettings.cs
+++ b/src/SendGrid/Helpers/Mail/Model/FooterSettings.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// The default footer that you would like appended to the bottom of every email.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class FooterSettings
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/Ganalytics.cs
+++ b/src/SendGrid/Helpers/Mail/Model/Ganalytics.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Allows you to enable tracking provided by Google Analytics.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class Ganalytics
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/HtmlContent.cs
+++ b/src/SendGrid/Helpers/Mail/Model/HtmlContent.cs
@@ -5,9 +5,12 @@
 
 namespace SendGrid.Helpers.Mail.Model
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Helper class for plain html mime types
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class HtmlContent : Content
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/MailSettings.cs
+++ b/src/SendGrid/Helpers/Mail/Model/MailSettings.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// A collection of different mail settings that you can use to specify how you would like this email to be handled.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class MailSettings
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/OpenTracking.cs
+++ b/src/SendGrid/Helpers/Mail/Model/OpenTracking.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Allows you to track whether the email was opened or not, but including a single pixel image in the body of the content. When the pixel is loaded, we can log that the email was opened.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class OpenTracking
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/Personalization.cs
+++ b/src/SendGrid/Helpers/Mail/Model/Personalization.cs
@@ -12,24 +12,25 @@ namespace SendGrid.Helpers.Mail
     /// An array of messages and their metadata. Each object within personalizations can be thought of as an envelope - it defines who should receive an individual message and how that message should be handled. For more information, please see our documentation on Personalizations. Parameters in personalizations will override the parameters of the same name from the message level.
     /// https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class Personalization
     {
         /// <summary>
         /// Gets or sets an array of recipients. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email.
         /// </summary>
-        [JsonProperty(PropertyName = "to")]
+        [JsonProperty(PropertyName = "to", IsReference = false)]
         public List<EmailAddress> Tos { get; set; }
 
         /// <summary>
         /// Gets or sets an array of recipients who will receive a copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email.
         /// </summary>
-        [JsonProperty(PropertyName = "cc")]
+        [JsonProperty(PropertyName = "cc", IsReference = false)]
         public List<EmailAddress> Ccs { get; set; }
 
         /// <summary>
         /// Gets or sets an array of recipients who will receive a blind carbon copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email.
         /// </summary>
-        [JsonProperty(PropertyName = "bcc")]
+        [JsonProperty(PropertyName = "bcc", IsReference = false)]
         public List<EmailAddress> Bccs { get; set; }
 
         /// <summary>
@@ -41,20 +42,20 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Gets or sets the object allowing you to specify specific handling instructions for your email.
         /// </summary>
-        [JsonProperty(PropertyName = "headers")]
+        [JsonProperty(PropertyName = "headers", IsReference = false)]
         public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets an object following the pattern "substitution_tag":"value to substitute". All are assumed to be strings. These substitutions will apply to the content of your email, in addition to the subject and reply-to parameters.
         /// You may not include more than 100 substitutions per personalization object, and the total collective size of your substitutions may not exceed 10,000 bytes per personalization object.
         /// </summary>
-        [JsonProperty(PropertyName = "substitutions")]
+        [JsonProperty(PropertyName = "substitutions", IsReference = false)]
         public Dictionary<string, string> Substitutions { get; set; }
 
         /// <summary>
         /// Gets or sets the values that are specific to this personalization that will be carried along with the email, activity data, and links. Substitutions will not be made on custom arguments. personalizations[x].custom_args will be merged with message level custom_args, overriding any conflicting keys. The combined total size of the resulting custom arguments, after merging, for each personalization may not exceed 10,000 bytes.
         /// </summary>
-        [JsonProperty(PropertyName = "custom_args")]
+        [JsonProperty(PropertyName = "custom_args", IsReference = false)]
         public Dictionary<string, string> CustomArgs { get; set; }
 
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/SandboxMode.cs
+++ b/src/SendGrid/Helpers/Mail/Model/SandboxMode.cs
@@ -11,6 +11,7 @@ namespace SendGrid.Helpers.Mail
     /// This allows you to send a test email to ensure that your request body is valid and formatted correctly. For more information, please see our Classroom.
     /// https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/sandbox_mode.html
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class SandboxMode
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/SpamCheck.cs
+++ b/src/SendGrid/Helpers/Mail/Model/SpamCheck.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// This allows you to test the content of your email for spam.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class SpamCheck
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/SubscriptionTracking.cs
+++ b/src/SendGrid/Helpers/Mail/Model/SubscriptionTracking.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Allows you to insert a subscription management link at the bottom of the text and html bodies of your email. If you would like to specify the location of the link within your email, you may use the substitution_tag.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class SubscriptionTracking
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/Model/TrackingSettings.cs
+++ b/src/SendGrid/Helpers/Mail/Model/TrackingSettings.cs
@@ -10,6 +10,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Settings to determine how you would like to track the metrics of how your recipients interact with your email.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class TrackingSettings
     {
         /// <summary>

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -14,6 +14,7 @@ namespace SendGrid.Helpers.Mail
     /// <summary>
     /// Class SendGridMessage builds an object that sends an email through SendGrid.
     /// </summary>
+    [JsonObject(IsReference = false)]
     public class SendGridMessage
     {
         /// <summary>
@@ -32,13 +33,13 @@ namespace SendGrid.Helpers.Mail
         /// Gets or sets a list of messages and their metadata. Each object within personalizations can be thought of as an envelope - it defines who should receive an individual message and how that message should be handled. For more information, please see our documentation on Personalizations. Parameters in personalizations will override the parameters of the same name from the message level.
         /// https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
         /// </summary>
-        [JsonProperty(PropertyName = "personalizations")]
+        [JsonProperty(PropertyName = "personalizations", IsReference = false)]
         public List<Personalization> Personalizations { get; set; }
 
         /// <summary>
         /// Gets or sets a list in which you may specify the content of your email. You can include multiple mime types of content, but you must specify at least one. To include more than one mime type, simply add another object to the array containing the type and value parameters. If included, text/plain and text/html must be the first indices of the array in this order. If you choose to include the text/plain or text/html mime types, they must be the first indices of the content array in the order text/plain, text/html.*Content is NOT mandatory if you using a transactional template and have defined the template_id in the Request
         /// </summary>
-        [JsonProperty(PropertyName = "content")]
+        [JsonProperty(PropertyName = "content", IsReference = false)]
         public List<Content> Contents { get; set; }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Gets or sets a list of objects in which you can specify any attachments you want to include.
         /// </summary>
-        [JsonProperty(PropertyName = "attachments")]
+        [JsonProperty(PropertyName = "attachments", IsReference = false)]
         public List<Attachment> Attachments { get; set; }
 
         /// <summary>
@@ -68,25 +69,25 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Gets or sets an object containing key/value pairs of header names and the value to substitute for them. You must ensure these are properly encoded if they contain unicode characters. Must not be any of the following reserved headers: x-sg-id, x-sg-eid, received, dkim-signature, Content-Type, Content-Transfer-Encoding, To, From, Subject, Reply-To, CC, BCC
         /// </summary>
-        [JsonProperty(PropertyName = "headers")]
+        [JsonProperty(PropertyName = "headers", IsReference = false)]
         public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets an object of key/value pairs that define large blocks of content that can be inserted into your emails using substitution tags.
         /// </summary>
-        [JsonProperty(PropertyName = "sections")]
+        [JsonProperty(PropertyName = "sections", IsReference = false)]
         public Dictionary<string, string> Sections { get; set; }
 
         /// <summary>
         /// Gets or sets a list of category names for this message. Each category name may not exceed 255 characters. You cannot have more than 10 categories per request.
         /// </summary>
-        [JsonProperty(PropertyName = "categories")]
+        [JsonProperty(PropertyName = "categories", IsReference = false)]
         public List<string> Categories { get; set; }
 
         /// <summary>
         /// Gets or sets values that are specific to the entire send that will be carried along with the email and its activity data. Substitutions will not be made on custom arguments, so any string that is entered into this parameter will be assumed to be the custom argument that you would like to be used. This parameter is overridden by any conflicting personalizations[x].custom_args if that parameter has been defined. If personalizations[x].custom_args has been defined but does not conflict with the values defined within this parameter, the two will be merged. The combined total size of these custom arguments may not exceed 10,000 bytes.
         /// </summary>
-        [JsonProperty(PropertyName = "custom_args")]
+        [JsonProperty(PropertyName = "custom_args", IsReference = false)]
         public Dictionary<string, string> CustomArgs { get; set; }
 
         /// <summary>

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -5980,6 +5980,73 @@
             // we can also test that the original exception was thrown
             Assert.IsType(typeof(TimeoutException), thrownException);
         }
+        
+        /// <summary>
+        /// Tests the conditions in issue #469.
+        /// JSON sent to SendGrid should never include reference handling ($id & $ref)
+        /// </summary>
+        /// <returns></returns>
+        [Theory]
+        [InlineData("$id")]
+        [InlineData("$ref")]
+        public void TestJsonNetReferenceHandling(string referenceHandlingProperty)
+        {
+            /* ****************************************************************************************
+             * Enable JSON.Net reference handling globally
+             * **************************************************************************************** */
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                PreserveReferencesHandling = PreserveReferencesHandling.All,
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+            };
+
+            /* ****************************************************************************************
+             * Create message with all possible properties
+             * **************************************************************************************** */
+            var msg = new SendGridMessage();
+
+            msg.SetBccSetting(true, "test@example.com");
+            msg.SetBypassListManagement(false);
+            msg.SetClickTracking(true, true);
+            msg.SetFooterSetting(true, "<strong>footer</strong>", "footer");
+            msg.SetFrom(new EmailAddress("test@example.com"));
+            msg.SetGlobalSendAt(0);
+            msg.SetGlobalSubject("globalSubject");
+            msg.SetGoogleAnalytics(true);
+            msg.SetIpPoolName("ipPoolName");
+            msg.SetOpenTracking(true, "substituteTag");
+            msg.SetReplyTo(new EmailAddress("test@example.com"));
+            msg.SetSandBoxMode(true);
+            msg.SetSendAt(0);
+            msg.SetSpamCheck(true);
+            msg.SetSubject("Hello World from the SendGrid CSharp Library");
+            msg.SetSubscriptionTracking(true);
+            msg.SetTemplateId("templateID");            
+
+            msg.AddAttachment("balance_001.pdf",
+                              "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12",
+                              "application/pdf",
+                              "attachment",
+                              "Balance Sheet");
+            msg.AddBcc("test@example.com");
+            msg.AddCategory("category");
+            msg.AddCc("test@example.com");
+            msg.AddContent(MimeType.Html, "HTML content");
+            msg.AddCustomArg("customArgKey", "customArgValue");
+            msg.AddGlobalCustomArg("globalCustomArgKey", "globalCustomValue");
+            msg.AddGlobalHeader("globalHeaderKey", "globalHeaderValue");
+            msg.AddHeader("headerKey", "headerValue");
+            msg.AddSection("sectionKey", "sectionValue");
+            msg.AddSubstitution("substitutionKey", "substitutionValue");
+            msg.AddTo(new EmailAddress("test@example.com"));
+            
+            /* ****************************************************************************************
+             * Serialize & check
+             * **************************************************************************************** */
+            string serializedMessage = msg.Serialize();
+            bool containsReferenceHandlingProperty = serializedMessage.Contains(referenceHandlingProperty);
+            Assert.False(containsReferenceHandlingProperty);
+        }
     }
 
     public class FakeHttpMessageHandler : HttpMessageHandler

--- a/tests/SendGrid.Tests/SendGrid.Tests.csproj
+++ b/tests/SendGrid.Tests/SendGrid.Tests.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
SendGrid rejects JSON containing $id and $ref properties which are added by Json.Net if reference handling is enabled. 

For projects which need this enabled it can either be disabled using a custom `ContractResolver` or annotating the objects itself with the `[JsonObject]` attribute. 

Settling this on the SendGrid Nuget side is imho cleaner and avoids trouble with future users.

It includes a test which looks for the $id/$ref properties in the serialized message. Please advise if I oversaw anything.

Issue: [#469](https://github.com/sendgrid/sendgrid-csharp/issues/469)