### PR TITLE
Important Typos.

### DIFF
--- a/examples/suppression/suppression.cs
+++ b/examples/suppression/suppression.cs
@@ -195,7 +195,7 @@ Console.ReadLine();
 // DELETE /suppression/spam_report/{email}
 
 var email = "test_url_param";
-var response = await client.RequestAsync(method: SendGridClient.Method.DELETE, urlPath: "suppression/spam_report/" + email);
+var response = await client.RequestAsync(method: SendGridClient.Method.DELETE, urlPath: "suppression/spam_reports/" + email);
 Console.WriteLine(response.StatusCode);
 Console.WriteLine(response.Body.ReadAsStringAsync().Result);
 Console.WriteLine(response.Headers.ToString());


### PR DESCRIPTION
// Delete a specific spam report
// DELETE /suppression/spam_reports/{email}
Needs an s on spam reports. Otherwise there will be a not found error.