### PR TITLE
Referencing signed version of Polly

### DIFF
--- a/nuspec/Sendgrid.9.6.0.nuspec
+++ b/nuspec/Sendgrid.9.6.0.nuspec
@@ -20,8 +20,10 @@
             <group targetFramework=".NETFramework4.0">
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="System.Net.Http" version="4.0.0" />
+                <dependency id="Polly-Signed" version="5.2.0" />
             </group>
             <group targetFramework=".NETStandard1.3">
+            	<dependency id="Polly-Signed" version="5.2.0" />
                 <dependency id="NETStandard.Library" version="1.6.1" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" />

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly" Version="5.2.0" />
+    <PackageReference Include="Polly-Signed" Version="5.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Need the signed version of the Polly package as the dependency in PackageReference.  Added this as the dependency in the group targets of the nuspec file. 


 

