### PR TITLE
Single email to multiple recipients - Toggle display of recipients

### DIFF
--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -165,7 +165,6 @@ namespace SendGrid.Helpers.Mail
                                                                             string htmlContent,
                                                                             bool showAllRecipients = false)
         {
-
             var msg = new SendGridMessage();
             if (showAllRecipients)
             {

--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -146,5 +146,49 @@ namespace SendGrid.Helpers.Mail
             var name = match.Groups[NameGroup].Value.Trim();
             return new EmailAddress(email, name);
         }
+
+        /// <summary>
+        /// Send a single simple email to multiple recipients with option for displaying all the recipients present in "To" section of email
+        /// </summary>
+        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
+        /// <param name="subject">The subject of your email. This may be overridden by SetGlobalSubject().</param>
+        /// <param name="plainTextContent">The text/plain content of the email body.</param>
+        /// <param name="htmlContent">The text/html content of the email body.</param>
+        /// <param name="showAllRecipients">Displays all the recipients present in the "To" section of email.The default value is false</param>
+        /// <returns>A SendGridMessage object.</returns>
+        public static SendGridMessage CreateSingleEmailToMultipleRecipients(
+                                                                            EmailAddress from,
+                                                                            List<EmailAddress> tos,
+                                                                            string subject,
+                                                                            string plainTextContent,
+                                                                            string htmlContent,
+                                                                            bool showAllRecipients = false)
+        {
+
+            var msg = new SendGridMessage();
+            if (showAllRecipients)
+            {
+                msg.SetFrom(from);
+                msg.SetGlobalSubject(subject);
+                if (!string.IsNullOrEmpty(plainTextContent))
+                {
+                    msg.AddContent(MimeType.Text, plainTextContent);
+                }
+
+                if (!string.IsNullOrEmpty(htmlContent))
+                {
+                    msg.AddContent(MimeType.Html, htmlContent);
+                }
+
+                msg.AddTos(tos);
+            }
+            else
+            {
+                msg = CreateSingleEmailToMultipleRecipients(from, tos, subject, plainTextContent, htmlContent);
+            }
+
+            return msg;
+        }
     }
 }

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -505,7 +505,7 @@
                                                                        true
                                                                        );
             Debug.WriteLine(msg6.Serialize());
-            Assert.True(msg6.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"},{\"email\":\"test2@example.com\"},{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text / plain\",\"value\":\"Plain Text Content\"},{\"type\":\"text / html\",\"value\":\"HTML Content\"}]}");
+            Assert.True(msg6.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"},{\"email\":\"test2@example.com\"},{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Plain Text Content\"},{\"type\":\"text/html\",\"value\":\"HTML Content\"}]}");
         }
 
         [Fact]

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -504,7 +504,6 @@
                                                                        "HTML Content",
                                                                        true
                                                                        );
-            Debug.WriteLine(msg6.Serialize());
             Assert.True(msg6.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"},{\"email\":\"test2@example.com\"},{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Plain Text Content\"},{\"type\":\"text/html\",\"value\":\"HTML Content\"}]}");
         }
 

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -449,6 +449,66 @@
         }
 
         [Fact]
+        public void TestCreateSingleEmailToMultipleRecipientsToggleRecipientDisplay()
+        {
+            var emails = new List<EmailAddress>
+            {
+                new EmailAddress("test1@example.com"),
+                new EmailAddress("test2@example.com"),
+                new EmailAddress("test3@example.com")
+            };
+            var msg = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                                       emails,
+                                                                       "Test Subject",
+                                                                       "Plain Text Content",
+                                                                       "HTML Content"
+                                                                       );
+            Assert.True(msg.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"}]},{\"to\":[{\"email\":\"test2@example.com\"}]},{\"to\":[{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Plain Text Content\"},{\"type\":\"text/html\",\"value\":\"HTML Content\"}]}");
+
+            var msg2 = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                                        emails,
+                                                                        "Test Subject",
+                                                                        null,
+                                                                        "HTML Content"
+                                                                        );
+            Assert.True(msg2.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"}]},{\"to\":[{\"email\":\"test2@example.com\"}]},{\"to\":[{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/html\",\"value\":\"HTML Content\"}]}");
+
+            var msg3 = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                                       emails,
+                                                                       "Test Subject",
+                                                                       "Plain Text Content",
+                                                                       null
+                                                                       );
+            Assert.True(msg3.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"}]},{\"to\":[{\"email\":\"test2@example.com\"}]},{\"to\":[{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Plain Text Content\"}]}");
+
+            var msg4 = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                            emails,
+                                                            "Test Subject",
+                                                            "",
+                                                            "HTML Content"
+                                                            );
+            Assert.True(msg4.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"}]},{\"to\":[{\"email\":\"test2@example.com\"}]},{\"to\":[{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/html\",\"value\":\"HTML Content\"}]}");
+
+            var msg5 = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                                       emails,
+                                                                       "Test Subject",
+                                                                       "Plain Text Content",
+                                                                       ""
+                                                                       );
+            Assert.True(msg5.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"}]},{\"to\":[{\"email\":\"test2@example.com\"}]},{\"to\":[{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text/plain\",\"value\":\"Plain Text Content\"}]}");
+
+            var msg6 = MailHelper.CreateSingleEmailToMultipleRecipients(new EmailAddress("test@example.com", "Example User"),
+                                                                       emails,
+                                                                       "Test Subject",
+                                                                       "Plain Text Content",
+                                                                       "HTML Content",
+                                                                       true
+                                                                       );
+            Debug.WriteLine(msg6.Serialize());
+            Assert.True(msg6.Serialize() == "{\"from\":{\"name\":\"Example User\",\"email\":\"test@example.com\"},\"subject\":\"Test Subject\",\"personalizations\":[{\"to\":[{\"email\":\"test1@example.com\"},{\"email\":\"test2@example.com\"},{\"email\":\"test3@example.com\"}]}],\"content\":[{\"type\":\"text / plain\",\"value\":\"Plain Text Content\"},{\"type\":\"text / html\",\"value\":\"HTML Content\"}]}");
+        }
+
+        [Fact]
         public void TestCreateMultipleEmailsToMultipleRecipients()
         {
             var emails = new List<EmailAddress>


### PR DESCRIPTION
This pull request is related to a new overload created for `CreateSingleEmailToMultipleRecipients` method in `MailHelper.cs` class. A new parameter named `showAllRecipients` has been added which toggles the display of all the recipients in the "To" section of email. The default value of the parameter is `false` , hence the all the recipients are not shown by default in the "To" section of email.