### PR TITLE
Corrected list all recipients documentation Fixes #351

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1511,9 +1511,8 @@ The Contacts API helps you manage your [Marketing Campaigns](https://sendgrid.co
 
 ```csharp
 string queryParams = @"{
-  'list_id': 1, 
   'page': 1, 
-  'page_size': 1
+  'page_size': 100
 }";
 var list_id = "test_url_param";
 var response = await client.RequestAsync(method: SendGridClient.Method.GET, urlPath: "contactdb/lists/" + list_id + "/recipients", queryParams: queryParams);


### PR DESCRIPTION
Fixed the example query for list all recipients to be the same as the one in SendGrid's documentation. Removed the list_id parameter that was incorrect.

Fixes #351