### PR TITLE
Made DeserializeResponseBody asynchronous Fixes #455

### DIFF
--- a/src/SendGrid/Response.cs
+++ b/src/SendGrid/Response.cs
@@ -5,12 +5,13 @@
 
 namespace SendGrid
 {
-    using Newtonsoft.Json;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// The response received from an API call to SendGrid
@@ -98,9 +99,10 @@ namespace SendGrid
         /// </summary>
         /// <param name="content">https://msdn.microsoft.com/en-us/library/system.net.http.httpcontent(v=vs.118).aspx</param>
         /// <returns>Dictionary object representation of HttpContent</returns>
-        public virtual Dictionary<string, dynamic> DeserializeResponseBody(HttpContent content)
+        public virtual async Task<Dictionary<string, dynamic>> DeserializeResponseBodyAsync(HttpContent content)
         {
-            var dsContent = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(content.ReadAsStringAsync().Result);
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+            var dsContent = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(stringContent);
             return dsContent;
         }
 


### PR DESCRIPTION
Issue #455 asked to add `ConfigureAwait(false)` to the  DeserializeResponseBody's call to ReadAsStringAsync. Since that call was synchronous (with Result) the only reason to add the ConfigureAwait(false) was to make it async. This means also changing the method's name to be coherent with the rest of the library.

Fixes issue #455