### PR TITLE
add .net standard 2.0 as target

### DIFF
--- a/ExampleCoreProject/ExampleCoreProject.csproj
+++ b/ExampleCoreProject/ExampleCoreProject.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>ExampleCoreProject</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ExampleCoreProject</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -20,4 +19,9 @@
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+  </ItemGroup>
+  
 </Project>

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>9.9.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net452</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SendGrid</AssemblyName>
@@ -27,6 +27,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/tests/SendGrid.Tests/SendGrid.Tests.csproj
+++ b/tests/SendGrid.Tests/SendGrid.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>SendGrid.Tests</AssemblyName>
     <PackageId>SendGrid.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
I've added .net standard 2.0 as target.
 - The ExampleCoreProject.csproj has now two targets (netcoreapp1.0 and netcoreap2.0)
 - The SendGrid.csproj now targets netstandard 1.3, netstandard 2.0 and net 452
 - SendGrid.Tests.csproj has now two targets (netcoreapp1.0 and netcoreap2.0)

I just now saw https://github.com/sendgrid/sendgrid-csharp/pull/559. But you can still take a look and maybe as you mentioned you prefere this pull request as it just adds the target instead of updating it.

For issue https://github.com/sendgrid/sendgrid-csharp/issues/550