### PR TITLE
.Net 4.5 References

### DIFF
--- a/nuspec/Sendgrid.9.9.0.nuspec
+++ b/nuspec/Sendgrid.9.9.0.nuspec
@@ -19,16 +19,22 @@
         <copyright>SendGrid, Inc. 2017</copyright>
         <tags>SendGrid Email Mail Microsoft Azure Transactional .NET Core</tags>
         <dependencies>
-            <group targetFramework=".NETFramework4.0">
+            <group targetFramework="net45">
+                <dependency id="Newtonsoft.Json" version="9.0.1" />
+            </group>
+            <group targetFramework="net40">
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="System.Net.Http" version="4.0.0" />
             </group>
-            <group targetFramework=".NETStandard1.3">
+            <group targetFramework="netstandard1.3">
                 <dependency id="NETStandard.Library" version="1.6.1" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" />
             </group>
         </dependencies>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net45" />
+        </frameworkAssemblies>
     </metadata>
     <files>
         <file src="lib\net452\SendGrid.dll" target="lib\net452\SendGrid.dll" />

--- a/nuspec/Sendgrid.9.9.0.nuspec
+++ b/nuspec/Sendgrid.9.9.0.nuspec
@@ -31,6 +31,10 @@
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" />
             </group>
+            <group targetFramework="netstandard2.0">
+                <dependency id="Newtonsoft.Json" version="9.0.1" />
+                <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" />
+            </group>
         </dependencies>
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net45" />

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>9.9.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net452</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SendGrid</AssemblyName>
@@ -26,6 +26,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
We don't need to reference the System.Net.Http package on .Net 4.5+ since it's provided by the framework.

I also update the targetFramework monikers to match the new ones at https://docs.microsoft.com/en-us/nuget/schema/target-frameworks