### PR TITLE
#638  Add default value for SubstitutionTag parameter

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -1420,7 +1420,7 @@ namespace SendGrid.Helpers.Mail
         /// </summary>
         /// <param name="enable">Gets or sets a value indicating whether this setting is enabled.</param>
         /// <param name="substitutionTag">Allows you to specify a substitution tag that you can insert in the body of your email at a location that you desire. This tag will be replaced by the open tracking pixel.</param>
-        public void SetOpenTracking(bool enable, string substitutionTag)
+        public void SetOpenTracking(bool enable, string substitutionTag = null)
         {
             if (this.TrackingSettings == null)
             {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- The `SendGridMessage` has the `SetOpenTracking` which takes two arguments `enable` and `substitutionTag`. The `substitutionTag` argument is optional and if user don't want to use it currently, they need to pass null explicitly as we have it as required. So I've set it to have default `null` value.

