### PR TITLE
Ignore Duplicate email addresses

### DIFF
--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -22,6 +22,9 @@ namespace SendGrid.Helpers.Mail
             $@"(?:(?<{NameGroup}>)(?<{EmailGroup}>[^\<]*@.*[^\>])|(?<{NameGroup}>[^\<]*)\<(?<{EmailGroup}>.*@.*)\>)",
             RegexOptions.ECMAScript);
 
+        private static readonly LambdaComparer<EmailAddress> EmailAddressComparer = new LambdaComparer<EmailAddress>(
+            (a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+
         /// <summary>
         /// Send a single simple email
         /// </summary>
@@ -116,8 +119,7 @@ namespace SendGrid.Helpers.Mail
                 msg.AddContent(MimeType.Html, htmlContent);
             }
 
-            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
-            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+            var distinctTos = tos.Distinct(EmailAddressComparer).ToList();
 
             for (var i = 0; i < distinctTos.Count; i++)
             {
@@ -152,8 +154,7 @@ namespace SendGrid.Helpers.Mail
 
             var setDynamicTemplateDataValues = dynamicTemplateData != null;
 
-            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
-            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+            var distinctTos = tos.Distinct(EmailAddressComparer).ToList();
 
             for (var i = 0; i < distinctTos.Count; i++)
             {
@@ -198,8 +199,7 @@ namespace SendGrid.Helpers.Mail
                 msg.AddContent(MimeType.Html, htmlContent);
             }
 
-            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
-            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+            var distinctTos = tos.Distinct(EmailAddressComparer).ToList();
 
             for (var i = 0; i < distinctTos.Count; i++)
             {
@@ -236,8 +236,7 @@ namespace SendGrid.Helpers.Mail
 
             var setDynamicTemplateDataValues = dynamicTemplateData != null;
 
-            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
-            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+            var distinctTos = tos.Distinct(EmailAddressComparer).ToList();
 
             for (var i = 0; i < distinctTos.Count; i++)
             {

--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -3,8 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using SendGrid.Helpers.Utility;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace SendGrid.Helpers.Mail
@@ -114,9 +116,12 @@ namespace SendGrid.Helpers.Mail
                 msg.AddContent(MimeType.Html, htmlContent);
             }
 
-            for (var i = 0; i < tos.Count; i++)
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+
+            for (var i = 0; i < distinctTos.Count; i++)
             {
-                msg.AddTo(tos[i], i);
+                msg.AddTo(distinctTos[i], i);
             }
 
             return msg;
@@ -147,9 +152,12 @@ namespace SendGrid.Helpers.Mail
 
             var setDynamicTemplateDataValues = dynamicTemplateData != null;
 
-            for (var i = 0; i < tos.Count; i++)
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+
+            for (var i = 0; i < distinctTos.Count; i++)
             {
-                msg.AddTo(tos[i], i);
+                msg.AddTo(distinctTos[i], i);
 
                 if (setDynamicTemplateDataValues)
                 {
@@ -190,9 +198,12 @@ namespace SendGrid.Helpers.Mail
                 msg.AddContent(MimeType.Html, htmlContent);
             }
 
-            for (var i = 0; i < tos.Count; i++)
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+
+            for (var i = 0; i < distinctTos.Count; i++)
             {
-                msg.AddTo(tos[i], i);
+                msg.AddTo(distinctTos[i], i);
                 msg.SetSubject(subjects[i], i);
                 msg.AddSubstitutions(substitutions[i], i);
             }
@@ -225,9 +236,12 @@ namespace SendGrid.Helpers.Mail
 
             var setDynamicTemplateDataValues = dynamicTemplateData != null;
 
-            for (var i = 0; i < tos.Count; i++)
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+            var distinctTos = tos.Distinct(emailAddressComparer).ToList();
+
+            for (var i = 0; i < distinctTos.Count; i++)
             {
-                msg.AddTo(tos[i], i);
+                msg.AddTo(distinctTos[i], i);
 
                 if (setDynamicTemplateDataValues)
                 {

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -5,6 +5,7 @@
 
 using Newtonsoft.Json;
 using SendGrid.Helpers.Mail.Model;
+using SendGrid.Helpers.Utility;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -214,9 +215,17 @@ namespace SendGrid.Helpers.Mail
         /// <param name="personalization">A personalization object to append to the message.</param>
         public void AddTos(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+
+            var distinctEmailAdress = emails.Distinct(emailAddressComparer).ToList();
+            if (distinctEmailAdress.Count == 0)
+            {
+                return;
+            }
+
             if (personalization != null)
             {
-                personalization.Tos.AddRange(emails);
+                personalization.Tos.AddRange(distinctEmailAdress);
                 if (this.Personalizations == null)
                 {
                     this.Personalizations = new List<Personalization>();
@@ -243,7 +252,7 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Tos = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Tos.AddRange(emails);
+                this.Personalizations[personalizationIndex].Tos.AddRange(distinctEmailAdress);
                 return;
             }
 
@@ -251,7 +260,7 @@ namespace SendGrid.Helpers.Mail
             {
                 new Personalization()
                 {
-                    Tos = emails
+                    Tos = distinctEmailAdress
                 }
             };
             return;
@@ -335,9 +344,17 @@ namespace SendGrid.Helpers.Mail
         /// <param name="personalization">A personalization object to append to the message.</param>
         public void AddCcs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+
+            var distinctEmailAdress = emails.Distinct(emailAddressComparer).ToList();
+            if (distinctEmailAdress.Count == 0)
+            {
+                return;
+            }
+
             if (personalization != null)
             {
-                personalization.Ccs.AddRange(emails);
+                personalization.Ccs.AddRange(distinctEmailAdress);
                 if (this.Personalizations == null)
                 {
                     this.Personalizations = new List<Personalization>();
@@ -364,7 +381,7 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Ccs = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Ccs.AddRange(emails);
+                this.Personalizations[personalizationIndex].Ccs.AddRange(distinctEmailAdress);
                 return;
             }
 
@@ -372,7 +389,7 @@ namespace SendGrid.Helpers.Mail
             {
                 new Personalization()
                 {
-                    Ccs = emails
+                    Ccs = distinctEmailAdress
                 }
             };
             return;
@@ -456,9 +473,17 @@ namespace SendGrid.Helpers.Mail
         /// <param name="personalization">A personalization object to append to the message.</param>
         public void AddBccs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            var emailAddressComparer = new LambdaComparer<EmailAddress>((a1, a2) => a1.Email.Equals(a2.Email, StringComparison.OrdinalIgnoreCase));
+
+            var distinctEmailAdress = emails.Distinct(emailAddressComparer).ToList();
+            if (distinctEmailAdress.Count == 0)
+            {
+                return;
+            }
+
             if (personalization != null)
             {
-                personalization.Bccs.AddRange(emails);
+                personalization.Bccs.AddRange(distinctEmailAdress);
                 if (this.Personalizations == null)
                 {
                     this.Personalizations = new List<Personalization>();
@@ -485,7 +510,7 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Bccs = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Bccs.AddRange(emails);
+                this.Personalizations[personalizationIndex].Bccs.AddRange(distinctEmailAdress);
                 return;
             }
 
@@ -493,7 +518,7 @@ namespace SendGrid.Helpers.Mail
             {
                 new Personalization()
                 {
-                    Bccs = emails
+                    Bccs = distinctEmailAdress
                 }
             };
             return;

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -190,7 +190,11 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Tos = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Tos.Add(email);
+                if (!this.Personalizations[personalizationIndex].Tos.Exists(a => a.Email.Equals(email.Email, StringComparison.OrdinalIgnoreCase)))
+                {
+                    this.Personalizations[personalizationIndex].Tos.Add(email);
+                }
+
                 return;
             }
 
@@ -319,7 +323,11 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Ccs = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Ccs.Add(email);
+                if (!this.Personalizations[personalizationIndex].Ccs.Exists(a => a.Email.Equals(email.Email, StringComparison.OrdinalIgnoreCase)))
+                {
+                    this.Personalizations[personalizationIndex].Ccs.Add(email);
+                }
+
                 return;
             }
 
@@ -448,7 +456,11 @@ namespace SendGrid.Helpers.Mail
                     this.Personalizations[personalizationIndex].Bccs = new List<EmailAddress>();
                 }
 
-                this.Personalizations[personalizationIndex].Bccs.Add(email);
+                if (!this.Personalizations[personalizationIndex].Bccs.Exists(a => a.Email.Equals(email.Email, StringComparison.OrdinalIgnoreCase)))
+                {
+                    this.Personalizations[personalizationIndex].Bccs.Add(email);
+                }
+
                 return;
             }
 

--- a/src/SendGrid/Helpers/Utility/LambdaComparer.cs
+++ b/src/SendGrid/Helpers/Utility/LambdaComparer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SendGrid.Helpers.Utility
+{
+    /// <summary>
+    /// This class could be used to write delegate comparers.
+    /// Especially useful for linq queries https://gist.github.com/kjellski/6267515
+    /// </summary>
+    /// <typeparam name="T">Type</typeparam>
+    public class LambdaComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T, T, bool> lambdaComparer;
+        private readonly Func<T, int> lambdaHash;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LambdaComparer{T}"/> class.
+        /// The comparer itself, initialized with
+        /// </summary>
+        /// <param name="lambdaComparer">Comparer</param>
+        public LambdaComparer(Func<T, T, bool> lambdaComparer)
+            : this(lambdaComparer, o => 0)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LambdaComparer{T}"/> class.
+        /// Constructor for generating the Comparer itself
+        /// </summary>
+        /// <param name="lambdaComparer">Comparer</param>
+        /// <param name="lambdaHash">Hash</param>
+        public LambdaComparer(Func<T, T, bool> lambdaComparer, Func<T, int> lambdaHash)
+        {
+            this.lambdaComparer = lambdaComparer ?? throw new ArgumentNullException("lambdaComparer");
+            this.lambdaHash = lambdaHash ?? throw new ArgumentNullException("lambdaHash");
+        }
+
+        /// <summary>
+        /// Equals with _labdaComparer
+        /// </summary>
+        /// <param name="x">X</param>
+        /// <param name="y">Y</param>
+        /// <returns>Result</returns>
+        public bool Equals(T x, T y)
+        {
+            return this.lambdaComparer(x, y);
+        }
+
+        /// <summary>
+        /// GetHashCode with _labdaHash
+        /// </summary>
+        /// <param name="obj">Object</param>
+        /// <returns>Hash code</returns>
+        public int GetHashCode(T obj)
+        {
+            return this.lambdaHash(obj);
+        }
+    }
+}

--- a/src/SendGrid/Helpers/Utility/LambdaComparer.cs
+++ b/src/SendGrid/Helpers/Utility/LambdaComparer.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// <copyright file="LambdaComparer.cs" company="SendGrid">
+// Copyright (c) SendGrid. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 using System.Collections.Generic;
 
 namespace SendGrid.Helpers.Utility

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -30,12 +30,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
@@ -104,6 +104,33 @@ namespace SendGrid.Tests.Helpers.Mail
         }
 
         [Fact]
+        public void TestCreateSingleEmailToMultipleDuplicateRecipients()
+        {
+            var from = new EmailAddress("from@email.com", "FromName");
+            var tos = new List<EmailAddress>
+            {
+                new EmailAddress("to1@email.com"),
+                new EmailAddress("to2@email.com"),
+                new EmailAddress("to1@email.com")
+            };
+
+            var subject = "Mail Subject";
+            var plainText = "Plain Text";
+
+            var sendGridMessage = MailHelper.CreateSingleEmailToMultipleRecipients(
+                from,
+                tos,
+                subject,
+                plainText,
+                null);
+
+            Assert.Equal(from, sendGridMessage.From);
+            Assert.Equal(tos[0], sendGridMessage.Personalizations.ElementAt(0).Tos.Single());
+            Assert.Equal(tos[1], sendGridMessage.Personalizations.ElementAt(1).Tos.Single());
+            Assert.Equal(2, sendGridMessage.Personalizations.Count);
+        }
+
+        [Fact]
         public void TestCreateMultipleTemplateEmailsToMultipleRecipients()
         {
             var from = new EmailAddress("from@email.com", "FromName");

--- a/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
@@ -78,8 +78,8 @@ namespace SendGrid.Tests.Helpers.Mail
             var tos = new List<EmailAddress>
             {
                 new EmailAddress("to1@email.com"),
-                new EmailAddress("to1@email.com"),
-                new EmailAddress("to2@email.com")
+                new EmailAddress("to2@email.com"),
+                new EmailAddress("to1@email.com")
             };
 
             var templateId = "d-template2";
@@ -97,6 +97,7 @@ namespace SendGrid.Tests.Helpers.Mail
             Assert.Equal(from, sendGridMessage.From);
             Assert.Equal(tos[0], sendGridMessage.Personalizations.ElementAt(0).Tos.Single());
             Assert.Equal(tos[1], sendGridMessage.Personalizations.ElementAt(1).Tos.Single());
+            Assert.Equal(2, sendGridMessage.Personalizations.Count);
             Assert.Equal(templateId, sendGridMessage.TemplateId);
             Assert.Equal(dynamicTemplateData, sendGridMessage.Personalizations.ElementAt(0).TemplateData);
             Assert.Equal(dynamicTemplateData, sendGridMessage.Personalizations.ElementAt(1).TemplateData);

--- a/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
@@ -160,5 +160,38 @@ namespace SendGrid.Tests.Helpers.Mail
             Assert.Equal(dynamicTemplateData[0], sendGridMessage.Personalizations.ElementAt(0).TemplateData);
             Assert.Equal(dynamicTemplateData[1], sendGridMessage.Personalizations.ElementAt(1).TemplateData);
         }
+
+        [Fact]
+        public void TestCreateMultipleTemplateEmailsToMultipleDuplicateRecipients()
+        {
+            var from = new EmailAddress("from@email.com", "FromName");
+            var tos = new List<EmailAddress>
+            {
+                new EmailAddress("to1@email.com"),
+                new EmailAddress("to2@email.com"),
+                new EmailAddress("to2@email.com")
+            };
+
+            var templateId = "d-template2";
+            var dynamicTemplateData = new List<object>
+            {
+                new { key1 = "value1" },
+                new { key2 = "value2" }
+            };
+
+            var sendGridMessage = MailHelper.CreateMultipleTemplateEmailsToMultipleRecipients(
+                from,
+                tos,
+                templateId,
+                dynamicTemplateData);
+
+            Assert.Equal(from, sendGridMessage.From);
+            Assert.Equal(tos[0], sendGridMessage.Personalizations.ElementAt(0).Tos.Single());
+            Assert.Equal(tos[1], sendGridMessage.Personalizations.ElementAt(1).Tos.Single());
+            Assert.Equal(2, sendGridMessage.Personalizations.Count);
+            Assert.Equal(templateId, sendGridMessage.TemplateId);
+            Assert.Equal(dynamicTemplateData[0], sendGridMessage.Personalizations.ElementAt(0).TemplateData);
+            Assert.Equal(dynamicTemplateData[1], sendGridMessage.Personalizations.ElementAt(1).TemplateData);
+        }
     }
 }

--- a/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
@@ -72,6 +72,37 @@ namespace SendGrid.Tests.Helpers.Mail
         }
 
         [Fact]
+        public void TestCreateSingleTemplateEmailToMultipleDuplicateRecipients()
+        {
+            var from = new EmailAddress("from@email.com", "FromName");
+            var tos = new List<EmailAddress>
+            {
+                new EmailAddress("to1@email.com"),
+                new EmailAddress("to1@email.com"),
+                new EmailAddress("to2@email.com")
+            };
+
+            var templateId = "d-template2";
+            var dynamicTemplateData = new Dictionary<string, object>
+            {
+                { "key1", "value1" }
+            };
+
+            var sendGridMessage = MailHelper.CreateSingleTemplateEmailToMultipleRecipients(
+                from,
+                tos,
+                templateId,
+                dynamicTemplateData);
+
+            Assert.Equal(from, sendGridMessage.From);
+            Assert.Equal(tos[0], sendGridMessage.Personalizations.ElementAt(0).Tos.Single());
+            Assert.Equal(tos[1], sendGridMessage.Personalizations.ElementAt(1).Tos.Single());
+            Assert.Equal(templateId, sendGridMessage.TemplateId);
+            Assert.Equal(dynamicTemplateData, sendGridMessage.Personalizations.ElementAt(0).TemplateData);
+            Assert.Equal(dynamicTemplateData, sendGridMessage.Personalizations.ElementAt(1).TemplateData);
+        }
+
+        [Fact]
         public void TestCreateMultipleTemplateEmailsToMultipleRecipients()
         {
             var from = new EmailAddress("from@email.com", "FromName");

--- a/tests/SendGrid.Tests/Helpers/Mail/SendGridMessageTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/SendGridMessageTests.cs
@@ -281,5 +281,21 @@
         }
 
         #endregion
+
+        [Fact]
+        public void SendGridMessage_MultipleTo()
+        {
+            // Arrange 
+            var sut = new SendGridMessage();
+
+            //Act
+            sut.AddTo("test@test.com");
+            sut.AddTo("test@test.com");
+            sut.AddTo("new@test.com");
+
+            //Assert
+            Assert.Equal(2, sut.Personalizations.FirstOrDefault().Tos.Count);
+        }
+
     }
 }


### PR DESCRIPTION
# Fixes #691 

### Checklist

- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- This fix Ignores adding duplicate email addresses in To,CC and BCC.
- This fix will only take unique email addresses.
- This fix is implemented on EmailHelpers as well as SendGridMessage Methods.
- Apart from that this also adds "LambdaComparer" in Helper-Utilities.