### PR TITLE
chore: Adds deploy phase that deploys to NuGet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)  
 
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: dotnet nuget push ./src/Sendgrid/bin/Release/SendGrid.*.nupkg --api-key $NUGET_API_KEY --source $NUGET_SOURCE
+  on:
+    branch: master
+    condition: '"x$NUGET_API_KEY" != "x" && "x$NUGET_SOURCE" != "x"'
+
 notifications:
   hipchat:
     rooms:


### PR DESCRIPTION
Inspired by the kubernetes-client/csharp Travis script, I created a deploy phase that uses dotnet nuget push to deploy the package directly to NuGet when the CI is run on master.

Two configuration needs to be added, NUGET_API_KEY that is the API key for NuGet and NUGET_SOURCE that contains the NuGet package name.

It is a first proposal to fix issue #752, I will update if it doesn't fit the requirement complety.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Adds a deploy phas to the Travis CI that publishes to NuGet

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
