### PR TITLE
Directly link online version of CLA and fix email mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ Quick links:
 
 - [Feature Request](https://github.com/sendgrid/sendgrid-csharp/tree/master/CONTRIBUTING.md#feature-request)
 - [Bug Reports](https://github.com/sendgrid/sendgrid-csharp/tree/master/CONTRIBUTING.md#submit-a-bug-report)
-- [Sign the CLA to Create a Pull Request](https://github.com/sendgrid/sendgrid-csharp/tree/master/CONTRIBUTING.md#cla)
 - [Improvements to the Codebase](https://github.com/sendgrid/sendgrid-csharp/tree/master/CONTRIBUTING.md#improvements-to-the-codebase)
 - [Review Pull Requests](https://github.com/sendgrid/sendgrid-csharp/tree/master/CONTRIBUTING.md#code-reviews)
+- Sign the CLA to Create a Pull Request [here](https://cla.sendgrid.com/sendgrid/sendgrid-csharp)
 
 <a name="troubleshooting"></a>
 # Troubleshooting
@@ -255,7 +255,10 @@ Please see our [troubleshooting guide](https://github.com/sendgrid/sendgrid-csha
 <a name="about"></a>
 # About
 
-sendgrid-csharp is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+sendgrid-csharp is guided and supported by the SendGrid Developer Experience Team.
+
+Email the Developer Experience Team [here](mailto:dx@sendgrid.com) in case of any assistance or queries.
+
 
 sendgrid-csharp is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-csharp are trademarks of SendGrid, Inc.
 


### PR DESCRIPTION
Update README.md to directly link the online version of the CLA and fix the email mentions

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

# Fixes #771 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Directly link to the online version of the CLA (Contributor License Agreement)
- Fix email mentions similar to sendgrid-python and sendgrid-java repositories.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
