### PR TITLE
Change the environment variable placeholders to be consistent amongst…

### DIFF
--- a/ExampleCoreProject/Example.cs
+++ b/ExampleCoreProject/Example.cs
@@ -17,7 +17,7 @@
         static async Task Execute()
         {
             // Retrieve the API key from the environment variables. See the project README for more info about setting this up.
-            var apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
+            var apiKey = Environment.GetEnvironmentVariable("NAME_OF_THE_ENVIRONMENT_VARIABLE_FOR_YOUR_SENDGRID_KEY");
 
             var client = new SendGridClient(apiKey);
 

--- a/ExampleNet45Project/Example.cs
+++ b/ExampleNet45Project/Example.cs
@@ -17,7 +17,7 @@
         static async Task Execute()
         {
             // Retrieve the API key from the environment variables. See the project README for more info about setting this up.
-            var apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY");
+            var apiKey = Environment.GetEnvironmentVariable("NAME_OF_THE_ENVIRONMENT_VARIABLE_FOR_YOUR_SENDGRID_KEY");
 
             var client = new SendGridClient(apiKey);
 


### PR DESCRIPTION
… all example projects.

### Short description of what this PR does:
This changes "SENDGRID_API" placeholder to the more widely used "NAME_OF_THE_ENVIRONMENT_VARIABLE_FOR_YOUR_SENDGRID_KEY" within the two example projects specified above. This keeps the environment variables consistent amongst all example projects as well as being completely unambiguous as to what should be placed here.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
