### PR TITLE
Add support for ASP.NET Core Dependency Injection

### DIFF
--- a/ExampleAspNetCoreProject/Controllers/EmailController.cs
+++ b/ExampleAspNetCoreProject/Controllers/EmailController.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using ExampleAspNetCoreProject.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using SendGrid;
+using SendGrid.Helpers.Mail;
+
+namespace ExampleAspNetCoreProject.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EmailController : ControllerBase
+    {
+        private readonly ILogger<EmailController> logger;
+        private readonly ISendGridClient client;
+
+        public EmailController(ILogger<EmailController> logger, ISendGridClient client)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        [HttpPost("send")]
+        public async Task<IActionResult> SendEmail([FromBody] SendEmailModel model)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var message = new SendGridMessage
+            {
+                HtmlContent = model.Content,
+                Subject = model.Subject,
+                From = new EmailAddress(model.From)
+            };
+
+            message.AddTo(model.Recipient);
+
+            logger.LogInformation($"Sending email to {model.Recipient} with subject {model.Subject}.");
+
+            var response = await client.SendEmailAsync(message);
+
+            logger.LogInformation($"SendGrid responded with status code: {response.StatusCode}");
+
+            return StatusCode((int) response.StatusCode);
+        }
+    }
+}

--- a/ExampleAspNetCoreProject/ExampleAspNetCoreProject.csproj
+++ b/ExampleAspNetCoreProject/ExampleAspNetCoreProject.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <UserSecretsId>adf5331b-3d39-4f3d-94f2-e5808d7e3a7a</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\SendGrid\SendGrid.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ExampleAspNetCoreProject/Models/SendEmailModel.cs
+++ b/ExampleAspNetCoreProject/Models/SendEmailModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ExampleAspNetCoreProject.Models
+{
+    public class SendEmailModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Recipient { get; set; }
+
+        [Required]
+        [EmailAddress]
+        public string From { get; set; }
+
+        [Required]
+        public string Subject { get; set; }
+
+        [Required]
+        public string Content { get; set; }
+    }
+}

--- a/ExampleAspNetCoreProject/Program.cs
+++ b/ExampleAspNetCoreProject/Program.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace ExampleAspNetCoreProject
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/ExampleAspNetCoreProject/Properties/launchSettings.json
+++ b/ExampleAspNetCoreProject/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:52446",
+      "sslPort": 44352
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ExampleAspNetCoreProject": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ExampleAspNetCoreProject/Startup.cs
+++ b/ExampleAspNetCoreProject/Startup.cs
@@ -1,0 +1,44 @@
+﻿using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SendGrid;
+
+namespace ExampleAspNetCoreProject
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Configure the SendGrid client based on the values specified in the application settings.
+            // We then register the Client and its options with the DI container, passing a singleton HttpClient instance
+            // to be used for making requests to the API. This allows us to inject the client into our controllers.
+            services.Configure<SendGridClientOptions>(Configuration.GetSection("SendGrid"));
+
+            services.AddSingleton(new HttpClient());
+            services.AddSingleton<ISendGridClient, SendGridClient>();
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/ExampleAspNetCoreProject/appsettings.Development.json
+++ b/ExampleAspNetCoreProject/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/ExampleAspNetCoreProject/appsettings.json
+++ b/ExampleAspNetCoreProject/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "SendGrid": {
+    "ApiKey": "",
+    "Host": "",
+    "Version": "",
+    "UrlPath": "" 
+  }
+}

--- a/ExampleAspNetCoreProject/appsettings.json
+++ b/ExampleAspNetCoreProject/appsettings.json
@@ -6,9 +6,6 @@
   },
   "AllowedHosts": "*",
   "SendGrid": {
-    "ApiKey": "",
-    "Host": "",
-    "Version": "",
-    "UrlPath": "" 
+    "ApiKey": ""
   }
 }

--- a/ExampleNet45Project/ExampleNet45.csproj
+++ b/ExampleNet45Project/ExampleNet45.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Example.cs" />

--- a/SendGrid.sln
+++ b/SendGrid.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29025.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{71C09624-020B-410E-A8FE-1FD216A1FE31}"
 EndProject
@@ -16,6 +16,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleCoreProject", "ExampleCoreProject\ExampleCoreProject.csproj", "{4BD07A97-8AD2-4134-848E-6A74EB992050}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleNet45", "ExampleNet45Project\ExampleNet45.csproj", "{3B3F2699-F720-4498-8044-262EFE110A22}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleAspNetCoreProject", "ExampleAspNetCoreProject\ExampleAspNetCoreProject.csproj", "{7C3D92E0-86DE-46A6-BE16-1E798DF728C8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{3B3F2699-F720-4498-8044-262EFE110A22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B3F2699-F720-4498-8044-262EFE110A22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B3F2699-F720-4498-8044-262EFE110A22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C3D92E0-86DE-46A6-BE16-1E798DF728C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C3D92E0-86DE-46A6-BE16-1E798DF728C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C3D92E0-86DE-46A6-BE16-1E798DF728C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C3D92E0-86DE-46A6-BE16-1E798DF728C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,5 +54,9 @@ Global
 		{D89ADAEA-2BE8-49AC-B5BC-6EABBB2AE4E3} = {D06BDAE9-BE83-448F-8AD4-3044BB187C11}
 		{4BD07A97-8AD2-4134-848E-6A74EB992050} = {D3201F71-A289-4136-AC7E-E5204ACB9183}
 		{3B3F2699-F720-4498-8044-262EFE110A22} = {D3201F71-A289-4136-AC7E-E5204ACB9183}
+		{7C3D92E0-86DE-46A6-BE16-1E798DF728C8} = {D3201F71-A289-4136-AC7E-E5204ACB9183}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12F463FA-F03B-48C9-8F64-5BED32F8D5D0}
 	EndGlobalSection
 EndGlobal

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -48,10 +48,16 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>2.2.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
@@ -60,6 +66,9 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using SendGrid.Helpers.Mail;
 using SendGrid.Helpers.Reliability;
@@ -70,6 +71,15 @@ namespace SendGrid
         /// <returns>Interface to the Twilio SendGrid REST API</returns>
         public SendGridClient(SendGridClientOptions options)
             : this(null, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendGridClient"/> class.
+        /// </summary>
+        /// <param name="options">An <see cref="IOptions{SendGridClientOptions}"/> instance specifying the configuration to be used with the client.</param>
+        public SendGridClient(IOptions<SendGridClientOptions> options)
+            : this(options.Value)
         {
         }
 

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -79,7 +79,7 @@ namespace SendGrid
         /// </summary>
         /// <param name="options">An <see cref="IOptions{SendGridClientOptions}"/> instance specifying the configuration to be used with the client.</param>
         public SendGridClient(IOptions<SendGridClientOptions> options)
-            : this(options.Value)
+            : this(options?.Value)
         {
         }
 
@@ -118,7 +118,7 @@ namespace SendGrid
         /// <param name="httpClient">The HTTP Client used to send requests to the SendGrid API.</param>
         /// <param name="options">An <see cref="IOptions{SendGridClientOptions}"/> instance specifying the configuration to be used with the client.</param>
         public SendGridClient(HttpClient httpClient, IOptions<SendGridClientOptions> options)
-            : this(httpClient, options?.Value ?? throw new ArgumentNullException(nameof(options)))
+            : this(httpClient, options?.Value)
         {
         }
 
@@ -130,7 +130,7 @@ namespace SendGrid
         /// <returns>Interface to the Twilio SendGrid REST API</returns>
         internal SendGridClient(HttpClient httpClient, SendGridClientOptions options)
         {
-            this.options = options;
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.client = httpClient ?? CreateHttpClientWithRetryHandler();
             if (this.options.RequestHeaders != null && this.options.RequestHeaders.TryGetValue(ContentType, out var contentType))
             {

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -42,12 +42,12 @@ namespace SendGrid
         /// <summary>
         /// The configuration to use with current <see cref="SendGridClient"/> instance
         /// </summary>
-        private SendGridClientOptions options;
+        private readonly SendGridClientOptions options;
 
         /// <summary>
         /// The HttpClient instance to use for all calls from this SendGridClient instance.
         /// </summary>
-        private HttpClient client;
+        private readonly HttpClient client;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SendGridClient"/> class.

--- a/tests/SendGrid.Tests/SendGrid.Tests.csproj
+++ b/tests/SendGrid.Tests/SendGrid.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>SendGrid.Tests</AssemblyName>
     <PackageId>SendGrid.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tests/SendGrid.Tests/SendGrid.Tests.csproj
+++ b/tests/SendGrid.Tests/SendGrid.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>SendGrid.Tests</AssemblyName>
     <PackageId>SendGrid.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
# Fixes #880 # 

This PR adds support for ASP.NET Core applications to use SendGrid with idiomatic dependency injection. I have tried to minimize the surface area impacted in `SendGridClient`, but had to make some modifications (most notably `InitializeClient()` handling some of the client initialization now).

Included is an example ASP.NET Core API with limited functionality which documents the usage of the new APIs and demonstrates how the various components interact.

While I've tested these changes and confirmed them to be working, I couldn't get the Integration tests to actually succeed due to `IntegrationFixture` apparently missing a file. Having reviewed the tests in question, I don't think these changes impact these tests at all, but I'd like to get a contributor's opinion on this.

If I've made a mistake in my code or assumptions, please let me know and I'd be happy to fix it.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Add `IOptions<SendGridClientOptions>` support to `SendGridClient`
- Enables the use of `services.AddTransient/Scoped/Singleton<ISendGridClient>` and subsequent injection into controllers
- Provides a basic example in ASP.NET Core 2.2 on how to use the client with dependency injection, and sending a basic e-mail from an API.

