### PR TITLE
Change default literals to C# 7 style literals

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -1054,7 +1054,7 @@ namespace SendGrid.Helpers.Mail
         /// <param name="content_id">A unique id that you specify for the attachment. This is used when the disposition is set to "inline" and the attachment is an image, allowing the file to be displayed within the body of your email. Ex: <![CDATA[ <img src="cid:ii_139db99fdb5c3704"></img> ]]></param>
         /// <param name="cancellationToken">A cancellation token which can notify if the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task AddAttachmentAsync(string filename, Stream contentStream, string type = null, string disposition = null, string content_id = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAttachmentAsync(string filename, Stream contentStream, string type = null, string disposition = null, string content_id = null, CancellationToken cancellationToken = default)
         {
             // Stream doesn't want us to read it, can't do anything else here
             if (contentStream == null || !contentStream.CanRead)

--- a/src/SendGrid/ISendGridClient.cs
+++ b/src/SendGrid/ISendGridClient.cs
@@ -45,7 +45,7 @@ namespace SendGrid
         /// <param name="request">The parameters for the API call</param>
         /// <param name="cancellationToken">Cancel the asynchronous call</param>
         /// <returns>Response object</returns>
-        Task<Response> MakeRequest(HttpRequestMessage request, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Response> MakeRequest(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Prepare for async call to the API server
@@ -60,7 +60,7 @@ namespace SendGrid
         /// through the internal http client. Any underlying exception will pass right through.
         /// In particular, this means that you may expect
         /// a TimeoutException if you are not connected to the internet.</exception>
-        Task<Response> RequestAsync(SendGridClient.Method method, string requestBody = null, string queryParams = null, string urlPath = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Response> RequestAsync(SendGridClient.Method method, string requestBody = null, string queryParams = null, string urlPath = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Make a request to send an email through Twilio SendGrid asynchronously.
@@ -68,6 +68,6 @@ namespace SendGrid
         /// <param name="msg">A SendGridMessage object with the details for the request.</param>
         /// <param name="cancellationToken">Cancel the asynchronous call.</param>
         /// <returns>A Response object.</returns>
-        Task<Response> SendEmailAsync(SendGridMessage msg, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Response> SendEmailAsync(SendGridMessage msg, CancellationToken cancellationToken = default);
     }
 }

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -189,7 +189,7 @@ namespace SendGrid
         /// <param name="request">The parameters for the API call</param>
         /// <param name="cancellationToken">Cancel the asynchronous call</param>
         /// <returns>Response object</returns>
-        public virtual async Task<Response> MakeRequest(HttpRequestMessage request, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<Response> MakeRequest(HttpRequestMessage request, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = await this.client.SendAsync(request, cancellationToken).ConfigureAwait(false);
             return new Response(response.StatusCode, response.Content, response.Headers);
@@ -209,11 +209,11 @@ namespace SendGrid
         /// In particular, this means that you may expect
         /// a TimeoutException if you are not connected to the Internet.</exception>
         public async Task<Response> RequestAsync(
-            SendGridClient.Method method,
+            Method method,
             string requestBody = null,
             string queryParams = null,
             string urlPath = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             var baseAddress = new Uri(string.IsNullOrWhiteSpace(this.options.Host) ? DefaultOptions.Host : this.options.Host);
             if (!baseAddress.OriginalString.EndsWith("/"))
@@ -251,7 +251,7 @@ namespace SendGrid
         /// <param name="msg">A SendGridMessage object with the details for the request.</param>
         /// <param name="cancellationToken">Cancel the asynchronous call.</param>
         /// <returns>A Response object.</returns>
-        public async Task<Response> SendEmailAsync(SendGridMessage msg, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Response> SendEmailAsync(SendGridMessage msg, CancellationToken cancellationToken = default)
         {
             return await this.RequestAsync(
                 Method.POST,
@@ -274,7 +274,7 @@ namespace SendGrid
         {
             if (webProxy != null)
             {
-                var httpClientHandler = new HttpClientHandler()
+                var httpClientHandler = new HttpClientHandler
                 {
                     Proxy = webProxy,
                     PreAuthenticate = true,
@@ -301,7 +301,7 @@ namespace SendGrid
         /// </returns>
         private string BuildUrl(string urlPath, string queryParams = null)
         {
-            string url = null;
+            string url;
 
             // create urlPAth - from parameter if overridden on call or from constructor parameter
             var urlpath = urlPath ?? this.options.UrlPath;
@@ -317,9 +317,9 @@ namespace SendGrid
 
             if (queryParams != null)
             {
-                var ds_query_params = this.ParseJson(queryParams);
+                var dsQueryParams = this.ParseJson(queryParams);
                 string query = "?";
-                foreach (var pair in ds_query_params)
+                foreach (var pair in dsQueryParams)
                 {
                     foreach (var element in pair.Value)
                     {


### PR DESCRIPTION
Small PR that changes `default(T)` usages to C# 7 style `default` literals.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
-  change `default(T)` usages to C# 7 style `default` literals
