### PR TITLE
feat: sanity-check email address and address lists when adding to a message

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -278,8 +278,14 @@ namespace SendGrid.Helpers.Mail
         /// <param name="email">An email recipient that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the cc email.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the email parameter is null</exception>
         public void AddCc(EmailAddress email, int personalizationIndex = 0, Personalization personalization = null)
         {
+            if (email == null)
+            {
+                throw new ArgumentNullException("email");
+            }
+
             if (personalization != null)
             {
                 personalization.Ccs = personalization.Ccs ?? new List<EmailAddress>();

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -384,6 +384,7 @@ namespace SendGrid.Helpers.Mail
         /// </summary>
         /// <param name="email">Specify the recipient's email.</param>
         /// <param name="name">Specify the recipient's name.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the email parameter is null or whitespace</exception>
         public void AddBcc(string email, string name = null)
         {
             if (string.IsNullOrWhiteSpace(email))
@@ -455,6 +456,8 @@ namespace SendGrid.Helpers.Mail
         /// <param name="emails">A list of bcc recipients. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the bcc emails.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the emails parameter is null</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when the emails parameter is empty</exception>
         public void AddBccs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
             if (emails == null)

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -262,6 +262,7 @@ namespace SendGrid.Helpers.Mail
         /// </summary>
         /// <param name="email">Specify the recipient's email.</param>
         /// <param name="name">Specify the recipient's name.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the email parameter is null or whitespace</exception>
         public void AddCc(string email, string name = null)
         {
             if (string.IsNullOrWhiteSpace(email))
@@ -339,8 +340,20 @@ namespace SendGrid.Helpers.Mail
         /// <param name="emails">A list of cc recipients. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the cc emails.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the emails parameter is null</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when the emails parameter is empty</exception>
         public void AddCcs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            if (emails == null)
+            {
+                throw new ArgumentNullException("emails");
+            }
+
+            if (emails.Count == 0)
+            {
+                throw new InvalidOperationException("Sequence contains no elements");
+            }
+
             if (personalization != null)
             {
                 personalization.Ccs.AddRange(emails);

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -457,6 +457,11 @@ namespace SendGrid.Helpers.Mail
         /// <param name="personalization">A personalization object to append to the message.</param>
         public void AddBccs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            if (emails == null)
+            {
+                throw new ArgumentNullException("emails");
+            }
+
             if (emails.Count == 0)
             {
                 throw new InvalidOperationException("Sequence contains no elements");

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using SendGrid.Helpers.Mail.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -456,6 +457,11 @@ namespace SendGrid.Helpers.Mail
         /// <param name="personalization">A personalization object to append to the message.</param>
         public void AddBccs(List<EmailAddress> emails, int personalizationIndex = 0, Personalization personalization = null)
         {
+            if (emails.Count == 0)
+            {
+                throw new InvalidOperationException("Sequence contains no elements");
+            }
+
             if (personalization != null)
             {
                 personalization.Bccs.AddRange(emails);

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -401,8 +401,14 @@ namespace SendGrid.Helpers.Mail
         /// <param name="email">An email recipient that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="personalizationIndex">Specify the index of the Personalization object where you want to add the bcc email.</param>
         /// <param name="personalization">A personalization object to append to the message.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when the email parameter is null</exception>
         public void AddBcc(EmailAddress email, int personalizationIndex = 0, Personalization personalization = null)
         {
+            if (email == null)
+            {
+                throw new ArgumentNullException("email");
+            }
+
             if (personalization != null)
             {
                 personalization.Bccs = personalization.Bccs ?? new List<EmailAddress>();

--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json;
 using SendGrid.Helpers.Mail.Model;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
+++ b/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
@@ -29,6 +29,20 @@ namespace SendGrid.Tests.PreSendEmailValidation
         }
 
         [Fact]
+        public void WithAnEmptyListOfCarbonCopiesThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<InvalidOperationException>(() => { sendGridMessage.AddCcs(new List<EmailAddress>()); });
+        }
+
+        [Fact]
+        public void WithANullListOfCarbonCopiesThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<InvalidOperationException>(() => { sendGridMessage.AddCcs(new List<EmailAddress>()); });
+        }
+
+        [Fact]
         public void WithANullCarbonCopyThenAnExceptionIsThrown()
         {
             var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);

--- a/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
+++ b/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
@@ -27,5 +27,12 @@ namespace SendGrid.Tests.PreSendEmailValidation
             var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
             Assert.Throws<ArgumentNullException>(() => { sendGridMessage.AddBcc(null, 0); });
         }
+
+        [Fact]
+        public void WithANullCarbonCopyThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<ArgumentNullException>(() => { sendGridMessage.AddCc(null, 0); });
+        }
     }
 }

--- a/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
+++ b/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
@@ -20,5 +20,12 @@ namespace SendGrid.Tests.PreSendEmailValidation
             var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
             Assert.Throws<ArgumentNullException>(() => { sendGridMessage.AddBccs(null); });
         }
+
+        [Fact]
+        public void WithANullBlindCarbonCopyThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<ArgumentNullException>(() => { sendGridMessage.AddBcc(null, 0); });
+        }
     }
 }

--- a/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
+++ b/tests/SendGrid.Tests/PreSendEmailValidation/WhenCreatingASendGridMessage.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using SendGrid.Helpers.Mail;
+using Xunit;
+
+namespace SendGrid.Tests.PreSendEmailValidation
+{
+    public class WhenCreatingASendGridMessage
+    {
+        [Fact]
+        public void WithAnEmptyListOfBlindCarbonCopiesThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<InvalidOperationException>(() => { sendGridMessage.AddBccs(new List<EmailAddress>()); });
+        }
+
+        [Fact]
+        public void WithANullListOfBlindCarbonCopiesThenAnExceptionIsThrown()
+        {
+            var sendGridMessage = MailHelper.CreateSingleEmail(new EmailAddress(), new EmailAddress(), string.Empty, string.Empty, string.Empty);
+            Assert.Throws<ArgumentNullException>(() => { sendGridMessage.AddBccs(null); });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #980 

When sending an email and providing an empty list of BCCs the request fails with BadRequest as outlined here: https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.personalizations.bcc

We want to inform the consumer that this is the case otherwise it may lead to email sending silenty failing.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #980 
Closes #980 
-->
# Fixes # 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
Pre send email validation to enforce the rules found here: https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.personalizations.bcc
