### PR TITLE
fix: add back client constructors with client options and actually use its reliability settings

### DIFF
--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -55,6 +55,27 @@ namespace SendGrid
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendGridClient"/> class.
+        /// </summary>
+        /// <param name="options">A <see cref="SendGridClientOptions"/> instance that defines the configuration settings to use with the client.</param>
+        /// <returns>Interface to the Twilio SendGrid REST API.</returns>
+        public SendGridClient(SendGridClientOptions options)
+            : base(options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendGridClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">An optional HTTP client which may me injected in order to facilitate testing.</param>
+        /// <param name="options">A <see cref="SendGridClientOptions"/> instance that defines the configuration settings to use with the client.</param>
+        /// <returns>Interface to the Twilio SendGrid REST API.</returns>
+        public SendGridClient(HttpClient httpClient, SendGridClientOptions options)
+            : base(httpClient, options)
+        {
+        }
+
         private static SendGridClientOptions buildOptions(string apiKey, string host, Dictionary<string, string> requestHeaders, string version, string urlPath)
         {
             return new SendGridClientOptions


### PR DESCRIPTION
Fixes https://github.com/sendgrid/sendgrid-csharp/issues/1000
Relates to https://github.com/sendgrid/sendgrid-csharp/pull/839

When the default client options were made static and the constructors later removed, there was no way to modify the reliability settings used by the retry handler. This fix adds back the constructors so clients can now be constructed with just the client options and the options will be used when creating a retry handler, if any.