### PR TITLE
feat: Added net40 target framework.

### DIFF
--- a/src/SendGrid/BaseClient.cs
+++ b/src/SendGrid/BaseClient.cs
@@ -7,10 +7,14 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+#if NET40
+using SendGrid.Helpers.Net40;
+#else
+using System.Reflection;
+#endif
 
 namespace SendGrid
 {

--- a/src/SendGrid/Helpers/Mail/Model/JsonConverters.cs
+++ b/src/SendGrid/Helpers/Mail/Model/JsonConverters.cs
@@ -7,7 +7,11 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if NET40
+using SendGrid.Helpers.Net40;
+#else
 using System.Reflection;
+#endif
 
 namespace SendGrid.Helpers.Mail
 {

--- a/src/SendGrid/Helpers/Net40/TypeExtensions.cs
+++ b/src/SendGrid/Helpers/Net40/TypeExtensions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SendGrid.Helpers.Net40
+{
+    internal static class TypeExtensions
+    {
+        public static Type GetTypeInfo(this Type type) => type;
+    }
+}

--- a/src/SendGrid/Helpers/TaskUtilities.cs
+++ b/src/SendGrid/Helpers/TaskUtilities.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SendGrid.Helpers
+{
+    internal static class TaskUtilities
+    {
+        public static Task Delay(TimeSpan delay, CancellationToken cancellationToken = default)
+        {
+#if NET40
+            return TaskEx.Delay(delay, cancellationToken);
+#else
+            return Task.Delay(delay, cancellationToken);
+#endif
+        }
+    }
+}

--- a/src/SendGrid/Reliability/RetryDelegatingHandler.cs
+++ b/src/SendGrid/Reliability/RetryDelegatingHandler.cs
@@ -83,7 +83,7 @@ namespace SendGrid.Helpers.Reliability
                     }
 
                     // ReSharper disable once MethodSupportsCancellation, cancel will be indicated on the token
-                    await Task.Delay(waitFor).ConfigureAwait(false);
+                    await TaskUtilities.Delay(waitFor).ConfigureAwait(false);
                 }
                 catch (HttpRequestException)
                 {
@@ -94,7 +94,7 @@ namespace SendGrid.Helpers.Reliability
                         throw;
                     }
 
-                    await Task.Delay(waitFor).ConfigureAwait(false);
+                    await TaskUtilities.Delay(waitFor).ConfigureAwait(false);
                 }
             }
 

--- a/src/SendGrid/SendGrid.csproj
+++ b/src/SendGrid/SendGrid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>9.16.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net452;net40</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
@@ -57,6 +57,12 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I saw that SendGrid.Net40 package is popular on NuGet. But, unfortunately, it has not been updated since 2015. In addition, I need this target to support the Windows XP version of the library (System.Net.Mail is available in net40, so I have to use the old method via SmtpClient). I am sure this can also help someone else.