### PR TITLE
fix: revert the 'SendGridClient' constructor changes

### DIFF
--- a/ExampleNet45Project/Program.cs
+++ b/ExampleNet45Project/Program.cs
@@ -26,7 +26,7 @@ namespace Example
             // Retrieve the API key.
             var apiKey = Environment.GetEnvironmentVariable("SENDGRID_API_KEY") ?? configuration["SendGrid:ApiKey"];
 
-            var client = new SendGridClient(HttpClient, apiKey, httpErrorAsException: true);
+            var client = new SendGridClient(HttpClient, new SendGridClientOptions { ApiKey = apiKey, HttpErrorAsException = true });
 
             // Send a Single Email using the Mail Helper
             var from = new EmailAddress(configuration.GetValue("SendGrid:From", "test@example.com"), "Example User");

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -64,10 +64,10 @@ Console.WriteLine(response.Body.ReadAsStringAsync().Result); // The message will
 Console.WriteLine(response.Headers.ToString());
 ```
 
-If you want to throw the exception when the API returns an error, init the SendGridClient with the parameter 'httpErrorAsException' as true:
+If you want to throw the exception when the API returns an error, init the SendGridClient with options including 'HttpErrorAsException' as true:
 
 ```csharp
-SendGridClient client = new SendGridClient(apiKey, httpErrorAsException: true);
+var client = new SendGridClient(new SendGridClientOptions{ ApiKey = apiKey, HttpErrorAsException = true });
 ```
 
 Then if an error is thrown due to a failed request, a summary of that error along with a link to the appropriate place in the documentation will be sent back as a JSON object in the Exception Message. You can also deserialize the JSON object as a SendGridErrorResponse. Every error status code returned by the API has its own type of exception (BadRequestException, UnauthorizedException, PayloadTooLargeException, SendGridInternalException, etc.). All the possibles status codes and errors are documented [here](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html).
@@ -77,7 +77,7 @@ Then if an error is thrown due to a failed request, a summary of that error alon
 #### 401 - Unauthorized
 
 ```csharp
-SendGridClient client = new SendGridClient("", httpErrorAsException: true);
+var client = new SendGridClient(new SendGridClientOptions{ ApiKey = "SG.12345678901234567890123456789012", HttpErrorAsException = true });
 
 try
 {
@@ -102,7 +102,7 @@ catch(Exception ex)
 #### 400 - Bad Request - From Email Null
 
 ```csharp
-var client = new SendGridClient(apiKey, httpErrorAsException: true);
+var client = new SendGridClient(new SendGridClientOptions{ ApiKey = apiKey, HttpErrorAsException = true });
 
 try
 {

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -20,10 +20,9 @@ namespace SendGrid
         /// <param name="requestHeaders">A dictionary of request headers.</param>
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
-        /// <param name="httpErrorAsException">Whether HTTP error responses should be raised as exceptions.</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(IWebProxy webProxy, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(webProxy, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
+            : base(webProxy, buildOptions(apiKey, host, requestHeaders, version, urlPath))
         {
         }
 
@@ -36,10 +35,9 @@ namespace SendGrid
         /// <param name="requestHeaders">A dictionary of request headers.</param>
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
-        /// <param name="httpErrorAsException">Whether HTTP error responses should be raised as exceptions.</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(HttpClient httpClient, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(httpClient, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
+            : base(httpClient, buildOptions(apiKey, host, requestHeaders, version, urlPath))
         {
         }
 
@@ -51,10 +49,9 @@ namespace SendGrid
         /// <param name="requestHeaders">A dictionary of request headers.</param>
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
-        /// <param name="httpErrorAsException">Whether HTTP error responses should be raised as exceptions.</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
-        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
+        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null)
+            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath))
         {
         }
 
@@ -79,7 +76,7 @@ namespace SendGrid
         {
         }
 
-        private static SendGridClientOptions buildOptions(string apiKey, string host, Dictionary<string, string> requestHeaders, string version, string urlPath, bool httpErrorAsException)
+        private static SendGridClientOptions buildOptions(string apiKey, string host, Dictionary<string, string> requestHeaders, string version, string urlPath)
         {
             return new SendGridClientOptions
             {
@@ -88,7 +85,6 @@ namespace SendGrid
                 RequestHeaders = requestHeaders ?? DefaultOptions.RequestHeaders,
                 Version = version ?? DefaultOptions.Version,
                 UrlPath = urlPath ?? DefaultOptions.UrlPath,
-                HttpErrorAsException = httpErrorAsException // No default needed for bool.
             };
         }
     }

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -5926,7 +5926,7 @@
             var responseMessage = Newtonsoft.Json.JsonConvert.SerializeObject(responseObject);
             var mockHandler = new FixedStatusAndMessageHttpMessageHandler(HttpStatusCode.ServiceUnavailable, responseMessage);
             var mockClient = new HttpClient(mockHandler);
-            var client = new SendGridClient(mockClient, fixture.apiKey, httpErrorAsException: true);
+            var client = new SendGridClient(mockClient, new SendGridClientOptions { ApiKey = fixture.apiKey, HttpErrorAsException = true });
 
             try
             {


### PR DESCRIPTION
Changes to released public method signatures are breaking changes. This fix reverts the recent constructor changes and replaces the example/tests with usage of `SendGridClientOptions` for passing the `HttpErrorAsException` flag.

Fixes #1027 