### PR TITLE
feat: allow the `RetryDelegatingHandler` to be used with `HttpClientFactory`

### DIFF
--- a/src/SendGrid/BaseClient.cs
+++ b/src/SendGrid/BaseClient.cs
@@ -234,7 +234,7 @@ namespace SendGrid
 
         private static HttpClient CreateHttpClientWithRetryHandler(BaseClientOptions options)
         {
-            return new HttpClient(new RetryDelegatingHandler(options.ReliabilitySettings));
+            return new HttpClient(new RetryDelegatingHandler(new HttpClientHandler(), options.ReliabilitySettings));
         }
 
         /// <summary>

--- a/src/SendGrid/Reliability/RetryDelegatingHandler.cs
+++ b/src/SendGrid/Reliability/RetryDelegatingHandler.cs
@@ -33,8 +33,8 @@ namespace SendGrid.Helpers.Reliability
         /// </summary>
         /// <param name="settings">A ReliabilitySettings instance.</param>
         public RetryDelegatingHandler(ReliabilitySettings settings)
-            : this(new HttpClientHandler(), settings)
         {
+            this.settings = settings;
         }
 
         /// <summary>

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -5872,7 +5872,10 @@
                 ReliabilitySettings = new ReliabilitySettings(1, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1))
             };
 
-            var retryHandler = new RetryDelegatingHandler(new HttpClientHandler(), options.ReliabilitySettings);
+            var retryHandler = new RetryDelegatingHandler(options.ReliabilitySettings);
+
+            // Verify we can set the inner handler after constrcution.
+            retryHandler.InnerHandler = new HttpClientHandler();
 
             HttpClient clientToInject = new HttpClient(retryHandler) { Timeout = TimeSpan.FromMilliseconds(1) };
             var sg = new SendGridClient(clientToInject, options.ApiKey);


### PR DESCRIPTION
A default inner handler should not be created by the delegating handler as required by the client factory. This change moves the creation of `HttpClientHandler` to the base client.

Fixes #1026 