### PR TITLE
docs: fix sender email object description in MailHelper.cs

### DIFF
--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -23,7 +23,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send a single simple email.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="to">An email object that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="subject">The subject of your email. This may be overridden by SetGlobalSubject().</param>
         /// <param name="plainTextContent">The text/plain content of the email body.</param>
@@ -56,7 +56,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send a single dynamic template email.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="to">An email object that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="templateId">The ID of the template.</param>
         /// <param name="dynamicTemplateData">The data with which to populate the dynamic template.</param>
@@ -88,7 +88,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send a single simple email to multiple recipients.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="subject">The subject of your email. This may be overridden by SetGlobalSubject().</param>
         /// <param name="plainTextContent">The text/plain content of the email body.</param>
@@ -125,7 +125,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send a single simple email to multiple recipients.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="templateId">The ID of the template.</param>
         /// <param name="dynamicTemplateData">The data with which to populate the dynamic template.</param>
@@ -163,7 +163,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send multiple emails to multiple recipients.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="subjects">The subject of your email. This may be overridden by SetGlobalSubject().</param>
         /// <param name="plainTextContent">The text/plain content of the email body.</param>
@@ -203,7 +203,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send multiple emails to multiple recipients.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="templateId">The ID of the template.</param>
         /// <param name="dynamicTemplateData">The data with which to populate the dynamic template.</param>
@@ -259,7 +259,7 @@ namespace SendGrid.Helpers.Mail
         /// <summary>
         /// Send a single simple email to multiple recipients with option for displaying all the recipients present in "To" section of email.
         /// </summary>
-        /// <param name="from">An email object that may contain the recipient’s name, but must always contain the sender’s email.</param>
+        /// <param name="from">An email object that may contain the sender’s name, but must always contain the sender’s email.</param>
         /// <param name="tos">A list of email objects that may contain the recipient’s name, but must always contain the recipient’s email.</param>
         /// <param name="subject">The subject of your email. This may be overridden by SetGlobalSubject().</param>
         /// <param name="plainTextContent">The text/plain content of the email body.</param>


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

I believe there are mistakes in the documentation for creating emails in `MailHelper.cs`.
I reckon that the `from` object should represent the sender, thus there should be the sender's name instead of the recipient's name.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
