### PR TITLE
CreateSingleEmailForMultipleRecipients should create single personalization for all of the recipients

### DIFF
--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -104,6 +104,8 @@ namespace SendGrid.Helpers.Mail
             var msg = new SendGridMessage();
             msg.SetFrom(from);
             msg.SetGlobalSubject(subject);
+            msg.AddTos(tos);
+
             if (!string.IsNullOrEmpty(plainTextContent))
             {
                 msg.AddContent(MimeType.Text, plainTextContent);
@@ -112,11 +114,6 @@ namespace SendGrid.Helpers.Mail
             if (!string.IsNullOrEmpty(htmlContent))
             {
                 msg.AddContent(MimeType.Html, htmlContent);
-            }
-
-            for (var i = 0; i < tos.Count; i++)
-            {
-                msg.AddTo(tos[i], i);
             }
 
             return msg;

--- a/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/MailHelperTests.cs
@@ -101,5 +101,34 @@ namespace SendGrid.Tests.Helpers.Mail
             Assert.Equal(dynamicTemplateData[0], sendGridMessage.Personalizations.ElementAt(0).TemplateData);
             Assert.Equal(dynamicTemplateData[1], sendGridMessage.Personalizations.ElementAt(1).TemplateData);
         }
+
+        [Theory]
+        [InlineData("plain text", null)]
+        [InlineData(null, "<p>html content</p>")]
+        public void TestCreateSingleEmailToMultipleRecipients(string plainTextContent, string htmlContent)
+        {
+            var from = new EmailAddress("from@email.com", "FromName");
+            var tos = new List<EmailAddress>
+            {
+                new EmailAddress("to1@email.com"),
+                new EmailAddress("to2@email.com")
+            };
+            var subject = "message subject";
+
+            var sendGridMessage = MailHelper.CreateSingleEmailToMultipleRecipients(
+                from,
+                tos,
+                subject,
+                plainTextContent,
+                htmlContent);
+
+            Assert.Equal(from, sendGridMessage.From);
+            Assert.Single(sendGridMessage.Personalizations);
+            Assert.Equal(subject, sendGridMessage.Personalizations[0].Subject);
+            Assert.Equal(tos[0], sendGridMessage.Personalizations[0].Tos[0]);
+            Assert.Equal(tos[1], sendGridMessage.Personalizations[0].Tos[1]);
+            Assert.Equal(htmlContent, sendGridMessage.HtmlContent);
+            Assert.Equal(plainTextContent, sendGridMessage.PlainTextContent);
+        }
     }
 }


### PR DESCRIPTION
fix: CreateSingleEmailToMultipleRecipients creating separate personalizations for each recipient

# Fixes #

Changes behavior of CreateSingleEmailToMultipleRecipients MailHelper method that it wont create mutliple personalizations for each recipient and allows for sending single email to all recipients as stated in method description.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
