### PR TITLE
feat: Add From Email to Personalization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2020, Twilio SendGrid, Inc. <help@twilio.com>
+Copyright (C) 2021, Twilio SendGrid, Inc. <help@twilio.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
feat: Add ability for Personalization to set the From Email address.

Note: The SendGrid API allows for the setting of the Personalization FromEmail and FromName but the sendgrid-csharp library does not. This small update allows these two fields to be set in the personalization.

Thank you!
Kind regards,
Joseph Little