### PR TITLE
fix: fallback to private body and headers for response deserialization

### DIFF
--- a/src/SendGrid/Response.cs
+++ b/src/SendGrid/Response.cs
@@ -107,15 +107,17 @@ namespace SendGrid
         /// <summary>
         /// Converts string formatted response body to a Dictionary.
         /// </summary>
+        /// <param name="content">https://docs.microsoft.com/dotnet/api/system.net.http.httpcontent.</param>
         /// <returns>Dictionary object representation of HttpContent.</returns>
-        public virtual async Task<Dictionary<string, dynamic>> DeserializeResponseBodyAsync()
+        public virtual async Task<Dictionary<string, dynamic>> DeserializeResponseBodyAsync(HttpContent content = null)
         {
-            if (this._body is null)
+            content = content ?? this._body;
+            if (content is null)
             {
                 return new Dictionary<string, dynamic>();
             }
 
-            var stringContent = await this._body.ReadAsStringAsync().ConfigureAwait(false);
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(false);
             var dsContent = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(stringContent);
             return dsContent;
         }
@@ -123,16 +125,19 @@ namespace SendGrid
         /// <summary>
         /// Converts string formatted response headers to a Dictionary.
         /// </summary>
+        /// <param name="headers">https://docs.microsoft.com/dotnet/api/system.net.http.headers.httpresponseheaders.</param>
         /// <returns>Dictionary object representation of HttpResponseHeaders.</returns>
-        public virtual Dictionary<string, string> DeserializeResponseHeaders()
+        public virtual Dictionary<string, string> DeserializeResponseHeaders(HttpResponseHeaders headers = null)
         {
             var dsContent = new Dictionary<string, string>();
-            if (this._headers == null)
+
+            headers = headers ?? this._headers;
+            if (headers == null)
             {
                 return dsContent;
             }
 
-            foreach (var pair in this._headers)
+            foreach (var pair in headers)
             {
                 dsContent.Add(pair.Key, pair.Value.First());
             }

--- a/tests/SendGrid.Tests/ResponseTests.cs
+++ b/tests/SendGrid.Tests/ResponseTests.cs
@@ -29,6 +29,15 @@ namespace SendGrid.Tests
         }
 
         [Fact]
+        public async Task DeserializeResponseBodyAsync_OverrideHttpContent_ReturnsBodyAsDictionary()
+        {
+            var content = "{\"scopes\": [\"alerts.read\"]}";
+            var response = new Response(HttpStatusCode.OK, null, null);
+            Dictionary<string, dynamic> responseBody = await response.DeserializeResponseBodyAsync(new StringContent(content));
+            Assert.Equal(new JArray() { "alerts.read" }, responseBody["scopes"]);
+        }
+
+        [Fact]
         public void DeserializeResponseHeaders_NullHttpResponseHeaders_ReturnsEmptyDictionary()
         {
             var response = new Response(HttpStatusCode.OK, null, null);
@@ -37,12 +46,22 @@ namespace SendGrid.Tests
         }
 
         [Fact]
-        public void DeserializeResponseHeaders_NullHttpResponseHeaders_ReturnsHeadersAsDictionary()
+        public void DeserializeResponseHeaders_HttpResponseHeaders_ReturnsHeadersAsDictionary()
         {
             var message = new HttpResponseMessage();
             message.Headers.Add("HeaderKey", "HeaderValue");
             var response = new Response(HttpStatusCode.OK, null, message.Headers);
             Dictionary<string, string> responseHeadersDeserialized = response.DeserializeResponseHeaders();
+            Assert.Equal("HeaderValue", responseHeadersDeserialized["HeaderKey"]);
+        }
+
+        [Fact]
+        public void DeserializeResponseHeaders_OverrideHttpResponseHeaders_ReturnsHeadersAsDictionary()
+        {
+            var message = new HttpResponseMessage();
+            message.Headers.Add("HeaderKey", "HeaderValue");
+            var response = new Response(HttpStatusCode.OK, null, null);
+            Dictionary<string, string> responseHeadersDeserialized = response.DeserializeResponseHeaders(message.Headers);
             Assert.Equal("HeaderValue", responseHeadersDeserialized["HeaderKey"]);
         }
     }


### PR DESCRIPTION
Reverts breaking change where public method signature was changed.

Relates to #1151 