### PR TITLE
fix: Use httpErrorAsException when passed as parameter to SendGridClient constructor

### DIFF
--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -20,6 +20,7 @@ namespace SendGrid
         /// <param name="requestHeaders">A dictionary of request headers.</param>
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
+        /// <param name="httpErrorAsException">Indicates whether HTTP error responses should be raised as exceptions. Default is false.</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(IWebProxy webProxy, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
             : base(webProxy, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
@@ -35,6 +36,7 @@ namespace SendGrid
         /// <param name="requestHeaders">A dictionary of request headers.</param>
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
+        /// <param name="httpErrorAsException">Indicates whether HTTP error responses should be raised as exceptions. Default is false.</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(HttpClient httpClient, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
             : base(httpClient, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
@@ -50,8 +52,8 @@ namespace SendGrid
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
-        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
+        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null)
+            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath, false))
         {
         }
 

--- a/src/SendGrid/SendGridClient.cs
+++ b/src/SendGrid/SendGridClient.cs
@@ -22,7 +22,7 @@ namespace SendGrid
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(IWebProxy webProxy, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(webProxy, buildOptions(apiKey, host, requestHeaders, version, urlPath))
+            : base(webProxy, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
         {
         }
 
@@ -37,7 +37,7 @@ namespace SendGrid
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
         public SendGridClient(HttpClient httpClient, string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
-            : base(httpClient, buildOptions(apiKey, host, requestHeaders, version, urlPath))
+            : base(httpClient, buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
         {
         }
 
@@ -50,8 +50,8 @@ namespace SendGrid
         /// <param name="version">API version, override AddVersion to customize.</param>
         /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint).</param>
         /// <returns>Interface to the Twilio SendGrid REST API.</returns>
-        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null)
-            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath))
+        public SendGridClient(string apiKey, string host = null, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null, bool httpErrorAsException = false)
+            : base(buildOptions(apiKey, host, requestHeaders, version, urlPath, httpErrorAsException))
         {
         }
 
@@ -76,7 +76,7 @@ namespace SendGrid
         {
         }
 
-        private static SendGridClientOptions buildOptions(string apiKey, string host, Dictionary<string, string> requestHeaders, string version, string urlPath)
+        private static SendGridClientOptions buildOptions(string apiKey, string host, Dictionary<string, string> requestHeaders, string version, string urlPath, bool httpErrorAsException)
         {
             return new SendGridClientOptions
             {
@@ -85,6 +85,7 @@ namespace SendGrid
                 RequestHeaders = requestHeaders ?? DefaultOptions.RequestHeaders,
                 Version = version ?? DefaultOptions.Version,
                 UrlPath = urlPath ?? DefaultOptions.UrlPath,
+                HttpErrorAsException = httpErrorAsException
             };
         }
     }

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -6132,7 +6132,7 @@
             await TestHttpErrorAsException((client, apiKey) => new SendGridClient(client, apiKey, httpErrorAsException: true));
         }
 
-        public async Task TestHttpErrorAsException(Func<HttpClient, string, SendGridClient> createClientFunc)
+        private async Task TestHttpErrorAsException(Func<HttpClient, string, SendGridClient> createClientFunc)
         {
             var responseObject = new
             {

--- a/tests/SendGrid.Tests/Integration.cs
+++ b/tests/SendGrid.Tests/Integration.cs
@@ -6121,7 +6121,18 @@
         }
 
         [Fact]
-        public async void TestHttpErrorAsException()
+        public async void TestHttpErrorAsExceptionWhenSetInOptions()
+        {
+            await TestHttpErrorAsException((client, apiKey) => new SendGridClient(client, new SendGridClientOptions {ApiKey = apiKey, HttpErrorAsException = true}));
+        }
+
+        [Fact]
+        public async void TestHttpErrorAsExceptionWhenSetAsParameter()
+        {
+            await TestHttpErrorAsException((client, apiKey) => new SendGridClient(client, apiKey, httpErrorAsException: true));
+        }
+
+        public async Task TestHttpErrorAsException(Func<HttpClient, string, SendGridClient> createClientFunc)
         {
             var responseObject = new
             {
@@ -6138,7 +6149,7 @@
             });
             var mockHandler = new FixedStatusAndMessageHttpMessageHandler(HttpStatusCode.ServiceUnavailable, responseMessage);
             var mockClient = new HttpClient(mockHandler);
-            var client = new SendGridClient(mockClient, new SendGridClientOptions { ApiKey = fixture.apiKey, HttpErrorAsException = true });
+            var client = createClientFunc(mockClient, fixture.apiKey);
 
             try
             {


### PR DESCRIPTION
# Fixes #

When passing `httpErrorAsException` as a parameter to the `SendGridClient` constructor, it was not used for anything. This PR passes the value the the options object created.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
