### PR TITLE
fix: reading from a stream that sends its data in multiple chunks

### DIFF
--- a/src/SendGrid/Helpers/Mail/SendGridMessage.cs
+++ b/src/SendGrid/Helpers/Mail/SendGridMessage.cs
@@ -566,7 +566,7 @@ namespace SendGrid.Helpers.Mail
         }
 
         /// <summary>
-        /// Add an attachment from a stream to the email. No attachment will be added in the case that the stream cannot be read. Streams of length greater than int.MaxValue are truncated.
+        /// Add an attachment from a stream to the email. No attachment will be added in the case that the stream cannot be read or is partially read. Streams of length greater than int.MaxValue are truncated.
         /// </summary>
         /// <param name="filename">The filename the attachment will display in the email.</param>
         /// <param name="contentStream">The stream to use as content of the attachment.</param>
@@ -585,12 +585,32 @@ namespace SendGrid.Helpers.Mail
 
             var contentLength = Convert.ToInt32(contentStream.Length);
             var streamBytes = new byte[contentLength];
+            var offset = 0;
 
-            await contentStream.ReadAsync(streamBytes, 0, contentLength, cancellationToken);
+            // while the stream is readable and we need to retrieve content
+            while (contentStream.CanRead && offset < contentLength)
+            {
+                // read the stream based on the current offset & content length needed
+                var lengthRead = await contentStream.ReadAsync(streamBytes, offset, contentLength - offset, cancellationToken);
 
-            var base64Content = Convert.ToBase64String(streamBytes);
+                // if the length read is 0 bytes it means we reached the end of the stream
+                // therefore break out of the while loop
+                if (lengthRead == 0)
+                {
+                    break;
+                }
 
-            this.AddAttachment(filename, base64Content, type, disposition, content_id);
+                // increment the offset by the amount read from the stream
+                offset += lengthRead;
+            }
+
+            // if the stream is fully read, add the attachement
+            if (offset == contentLength)
+            {
+                var base64Content = Convert.ToBase64String(streamBytes);
+
+                this.AddAttachment(filename, base64Content, type, disposition, content_id);
+            }
         }
 
         /// <summary>

--- a/tests/SendGrid.Tests/Helpers/Mail/ChunkedReadableStream.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/ChunkedReadableStream.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace SendGrid.Tests.Helpers.Mail
+{
+
+    public class ChunkedReadableStream : NonReadableStream
+    {
+        public ChunkedReadableStream(int length, int steps)
+        {
+            Length = length;
+            PositionStepSize = length / steps;
+        }
+
+        public int PositionStepSize { get; }
+
+        public int CurrentStep => (int)(Position / PositionStepSize);
+
+        public override bool CanRead => true;
+
+        public override long Length { get; }
+
+        public override long Position { get; set; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // limit the "bytes read" by the following:
+            // - step size
+            // - remaining step size
+            // - the given count
+            // - the remaining length of the buffer.
+            var bytesRead = Math.Min(
+                                Math.Min(PositionStepSize, Length - Position),
+                                Math.Min(count, buffer.Length - offset));
+
+            // increment the current position of the stream
+            Position += bytesRead;
+
+            return (int)bytesRead;
+        }
+    }
+}

--- a/tests/SendGrid.Tests/Helpers/Mail/SendGridMessageTests.cs
+++ b/tests/SendGrid.Tests/Helpers/Mail/SendGridMessageTests.cs
@@ -180,6 +180,29 @@
 
         #region AddAttachmentAsync tests
 
+
+        [Theory]
+        [InlineData(1024, 1)]
+        [InlineData(1024, 2)]
+        [InlineData(1024, 4)]
+        [InlineData(4096, 1)]
+        [InlineData(4096, 8)]
+        [InlineData(4096, 16)]
+        public async Task SendGridMessage_AddAttachmentAsync_Read_Chunked_Readable_Streams(int contentLength, int steps)
+        {
+            // Arrange
+            var sut = new SendGridMessage();
+            var stream = new ChunkedReadableStream(contentLength, steps);
+
+            // Act
+            await sut.AddAttachmentAsync("test", stream);
+
+            // Assert
+            Assert.NotNull(sut.Attachments);
+            Assert.Single(sut.Attachments);
+            Assert.Equal(steps, stream.CurrentStep);
+        }
+
         [Fact]
         public async Task SendGridMessage_AddAttachmentAsync_Doesnt_Read_Non_Readable_Streams()
         {


### PR DESCRIPTION
# Fixes #

A bug where the stream is only read once and the return value length isn't validated against the total expected length.
Example: if a stream sends the data in 4 chunks only the first chunk is read from the stream.

# Adds #

A test with a stream that simulates sending the data in seperate (configurable) chunks.

# Checklist #
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

